### PR TITLE
rc-1.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,74 @@
+name: "Bug Report"
+description: "Submit a bug report to help us improve the library"
+title: "Bug Report: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+  - type: textarea
+    id: reproduction
+    validations:
+      required: true
+    attributes:
+      label: "Reproduction steps"
+      description: "Please provide a step by step walkthrough on how to reproduce the bug."
+      placeholder: >
+        1) First step...
+        2) Second step....
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: "Expected behavior"
+      description: "What did you expect to happen?"
+      placeholder: "Expected Result..."
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: "Actual Behavior"
+      description: "What did actually happen? (Add any useful information if available ex. screenshots or logs)"
+      placeholder: "Actual Result... "
+  - type: dropdown
+    id: appwrite-version
+    attributes:
+      label: ".NET version"
+      description: "What version of .NET are you running?"
+      options:
+        - .NET Core 3.1.x
+        - .NET Framework 5.0.x
+        - .NET Framework 6.0.x
+        - Other (specify in environment)
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: "Operating system"
+      description: "What OS are you using to reproduce the bug?"
+      options:
+        - Linux
+        - MacOS
+        - Windows
+        - Other (specify in environment)
+    validations:
+      required: true
+  - type: textarea
+    id: enviromnemt
+    validations:
+      required: false
+    attributes:
+      label: "Environment"
+      description: "Any additional differences in your environment which may relate to the issue"
+      placeholder: ""
+  - type: textarea
+    id: dotnet-info
+    attributes:
+      label: dotnet --info
+      description: Run the dotnet --info command and copy and paste the results
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,17 @@
+name: "Documentation"
+description: "Documentation report"
+title: "Documentation: "
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to help us improve our documentation 
+  - type: textarea
+    id: issue-description
+    validations:
+      required: true
+    attributes:
+      label: "Description"
+      description: "A clear and concise description of what the issue is."
+      placeholder: "Suggestion to change the documentation for..."

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,28 @@
+name: .NET Distributable 
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, rc-** ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET on 3.1.x, 5.0.x, 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          5.0.x
+          6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build Src/Spot --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: .NET Main Workflow
 
 on:
   push:
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET
+    - name: Setup .NET 5.0.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Distributables
+
+on:
+  release:
+    types:
+      - published
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET on 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version:  6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release
+    - name: Pack
+      run: dotnet pack Src/Spot -p:NuspecFile=.nuspec -p:RepositoryBranch=${{ github.event.release.tag_name }} -o Release
+    - name: Upload
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./Release/Binance.Spot.${{ github.event.release.tag_name }}.nupkg
+        asset_name: Binance.Spot.${{ github.event.release.tag_name }}.nupkg
+        asset_content_type: binary/octet-stream
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## 1.1.0 - 2022-01-19
+### Added
+- New endpoints for BSwap
+  - GET /sapi/v1/bswap/poolConfigure to get pool configure
+  - GET /sapi/v1/bswap/addLiquidityPreview to get add liquidity preview
+  - GET /sapi/v1/margin/isolated/accountLimit to get remove liquidity preview
+  - GET /sapi/v1/bswap/unclaimedRewards to get unclaimed rewards record.
+  - POST /sapi/v1/bswap/claimRewards to claim swap rewards or liquidity rewards.
+  - GET /sapi/v1/bswap/claimedHistory to get history of claimed rewards.
+
+- New endpoints for Trade:
+  - GET api/v3/rateLimit/order added
+
+- New endpoint for Crypto Loans
+  - GET /sapi/v1/loan/income
+
+- New endpoint for Pay
+  - GET /sapi/v1/pay/transactions to support user query Pay trade history
+
+- New endpoint for Convert
+  - GET /sapi/v1/convert/tradeFlow to support user query convert trade history records
+
+- New endpoint for Rebate
+  - GET /sapi/v1/rebate/taxQuery to support user query spot rebate history records
+
+- New endpoint for Margin
+  - GET /sapi/v1/margin/crossMarginData to get cross margin fee data collection
+  - GET /sapi/v1/margin/isolatedMarginData to get isolated margin fee data collection
+  - GET /sapi/v1/margin/isolatedMarginTier to get isolated margin tier data collection
+
+- New endpoints for NFT
+  - GET /sapi/v1/nft/history/transactions to get NFT transaction history
+  - GET /sapi/v1/nft/history/deposit to get NFT deposit history
+  - GET /sapi/v1/nft/history/withdraw to get NFT withdraw history
+  - GET /sapi/v1/nft/user/getAsset to get NFT asset
+
+- New endpoint for Mining
+  - GET /sapi/v1/mining/payment/uid to get Mining account earning.
+
+- New endpoints for Sub-Account
+  - POST /sapi/v1/sub-account/subAccountApi/ipRestriction to support master account enable and disable IP restriction for a sub-account API Key
+  - POST /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList to support master account add IP list for a sub-account API Key
+  - GET /sapi/v1/account/apiRestrictions/ipRestriction to support master account query IP restriction for a sub-account API Key
+  - DELETE /sapi/v1/account/apiRestrictions/ipRestriction/ipList to support master account delete IP list for a sub-account API Key
+
+- Issue templates
+  - Added templates for bug report and documentation changes 
+
+- Actions
+  - Added release action
+  - Added multi-framework distributable build tests
+
+### Updated
+- Updated endpoints for Sub-Account
+  - New parameter clientTranId added in POST /sapi/v1/sub-account/universalTransfer and GET /sapi/v1/sub-account/universalTransfer to support custom transfer id
+
+- Updated endpoint for Wallet and Futures
+  - GET /sapi/v1/asset/transfer
+  - GET /sapi/v1/futures/transfer
+  - GET /sapi/v1/accountSnapshot
+  - The query time range of both endpoints are shortened to support data query within the last 6 months only, where startTime does not support selecting a timestamp beyond 6 months.
+If you do not specify startTime and endTime, the data of the last 7 days will be returned by default.
+
+- Updated endpoints for Wallet
+  - New parameter walletType added in POST /sapi/v1/capital/withdraw/apply
+
+- Updated endpoints for Margin
+  - Removed out limit from GET /sapi/v1/margin/interestRateHistory
+  - As the Mining account is merged into Funding account, transfer types MAIN_MINING, MINING_MAIN, MINING_UMFUTURE, MARGIN_MINING, and MINING_MARGIN will be discontinued in Universal Transfer endpoint POST /sapi/v1/asset/transfer on January 05, 2022 08:00 AM UTC
+
+- Resolved lint warnings
+
+- Improved Http Exceptions
+
 ## 1.0.1 - 2022-01-10
 
 ### Added

--- a/Examples/CSharp/BSwap/AddLiquidityPreview_Example.cs
+++ b/Examples/CSharp/BSwap/AddLiquidityPreview_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.BSwapExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class AddLiquidityPreview_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<AddLiquidityPreview_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var bSwap = new BSwap(httpClient);
+
+            var result = await bSwap.AddLiquidityPreview(2, "SINGLE", "USDT", 1.1m);
+        }
+    }
+}

--- a/Examples/CSharp/BSwap/ClaimRewards_Example.cs
+++ b/Examples/CSharp/BSwap/ClaimRewards_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.BSwapExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class ClaimRewards_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<ClaimRewards_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var bSwap = new BSwap(httpClient);
+
+            var result = await bSwap.ClaimRewards();
+        }
+    }
+}

--- a/Examples/CSharp/BSwap/GetClaimedHistory_Example.cs
+++ b/Examples/CSharp/BSwap/GetClaimedHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.BSwapExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetClaimedHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetClaimedHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var bSwap = new BSwap(httpClient);
+
+            var result = await bSwap.GetClaimedHistory();
+        }
+    }
+}

--- a/Examples/CSharp/BSwap/GetUnclaimedRewardsRecord_Example.cs
+++ b/Examples/CSharp/BSwap/GetUnclaimedRewardsRecord_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.BSwapExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetUnclaimedRewardsRecord_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetUnclaimedRewardsRecord_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var bSwap = new BSwap(httpClient);
+
+            var result = await bSwap.GetUnclaimedRewardsRecord();
+        }
+    }
+}

--- a/Examples/CSharp/BSwap/PoolConfigure_Example.cs
+++ b/Examples/CSharp/BSwap/PoolConfigure_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.BSwapExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class PoolConfigure_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<PoolConfigure_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var bSwap = new BSwap(httpClient);
+
+            var result = await bSwap.PoolConfigure();
+        }
+    }
+}

--- a/Examples/CSharp/Convert/GetConvertTradeHistory_Example.cs
+++ b/Examples/CSharp/Convert/GetConvertTradeHistory_Example.cs
@@ -1,0 +1,29 @@
+namespace Binance.Spot.ConvertExamples
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetConvertTradeHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetConvertTradeHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var convert = new Convert(httpClient);
+
+            var result = await convert.GetConvertTradeHistory(1639646747000, 1642325147000);
+        }
+    }
+}

--- a/Examples/CSharp/CryptoLoans/GetCryptoLoansIncomeHistory_Example.cs
+++ b/Examples/CSharp/CryptoLoans/GetCryptoLoansIncomeHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.CryptoLoansExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetCryptoLoansIncomeHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetCryptoLoansIncomeHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var cryptoLoans = new CryptoLoans(httpClient);
+
+            var result = await cryptoLoans.GetCryptoLoansIncomeHistory("BTC");
+        }
+    }
+}

--- a/Examples/CSharp/MarginAccountTrade/QueryCrossMarginFeeData_Example.cs
+++ b/Examples/CSharp/MarginAccountTrade/QueryCrossMarginFeeData_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.MarginAccountTradeExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class QueryCrossMarginFeeData_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<QueryCrossMarginFeeData_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var margin = new MarginAccountTrade(httpClient);
+
+            var result = await margin.QueryCrossMarginFeeData();
+        }
+    }
+}

--- a/Examples/CSharp/MarginAccountTrade/QueryIsolatedMarginFeeData_Example.cs
+++ b/Examples/CSharp/MarginAccountTrade/QueryIsolatedMarginFeeData_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.MarginAccountTradeExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class QueryIsolatedMarginFeeData_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<QueryIsolatedMarginFeeData_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var margin = new MarginAccountTrade(httpClient);
+
+            var result = await margin.QueryIsolatedMarginFeeData();
+        }
+    }
+}

--- a/Examples/CSharp/MarginAccountTrade/QueryIsolatedMarginTierData_Example.cs
+++ b/Examples/CSharp/MarginAccountTrade/QueryIsolatedMarginTierData_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.MarginAccountTradeExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class QueryIsolatedMarginTierData_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<QueryIsolatedMarginTierData_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var margin = new MarginAccountTrade(httpClient);
+
+            var result = await margin.QueryIsolatedMarginTierData("BNBUSDT");
+        }
+    }
+}

--- a/Examples/CSharp/Mining/MiningAccountEarning_Example.cs
+++ b/Examples/CSharp/Mining/MiningAccountEarning_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.MiningExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class MiningAccountEarning_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<MiningAccountEarning_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var mining = new Mining(httpClient);
+
+            var result = await mining.MiningAccountEarning("sha256");
+        }
+    }
+}

--- a/Examples/CSharp/NFT/GetNftAsset_Example.cs
+++ b/Examples/CSharp/NFT/GetNftAsset_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.NFTExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetNftAsset_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetNftAsset_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var nFT = new NFT(httpClient);
+
+            var result = await nFT.GetNftAsset();
+        }
+    }
+}

--- a/Examples/CSharp/NFT/GetNftDepositHistory_Example.cs
+++ b/Examples/CSharp/NFT/GetNftDepositHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.NFTExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetNftDepositHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetNftDepositHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var nFT = new NFT(httpClient);
+
+            var result = await nFT.GetNftDepositHistory();
+        }
+    }
+}

--- a/Examples/CSharp/NFT/GetNftTransactionHistory_Example.cs
+++ b/Examples/CSharp/NFT/GetNftTransactionHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.NFTExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetNftTransactionHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetNftTransactionHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var nFT = new NFT(httpClient);
+
+            var result = await nFT.GetNftTransactionHistory(1);
+        }
+    }
+}

--- a/Examples/CSharp/NFT/GetNftWithdrawHistory_Example.cs
+++ b/Examples/CSharp/NFT/GetNftWithdrawHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.NFTExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetNftWithdrawHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetNftWithdrawHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var nFT = new NFT(httpClient);
+
+            var result = await nFT.GetNftWithdrawHistory();
+        }
+    }
+}

--- a/Examples/CSharp/Pay/GetPayTradeHistory_Example.cs
+++ b/Examples/CSharp/Pay/GetPayTradeHistory_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.PayExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetPayTradeHistory_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetPayTradeHistory_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var pay = new Pay(httpClient);
+
+            var result = await pay.GetPayTradeHistory();
+        }
+    }
+}

--- a/Examples/CSharp/Rebate/GetSpotRebateHistoryRecords_Example.cs
+++ b/Examples/CSharp/Rebate/GetSpotRebateHistoryRecords_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.RebateExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetSpotRebateHistoryRecords_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetSpotRebateHistoryRecords_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var rebate = new Rebate(httpClient);
+
+            var result = await rebate.GetSpotRebateHistoryRecords();
+        }
+    }
+}

--- a/Examples/CSharp/SpotAccountTrade/QueryCurrentOrderCountUsage_Example.cs
+++ b/Examples/CSharp/SpotAccountTrade/QueryCurrentOrderCountUsage_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.SpotAccountTradeExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class QueryCurrentOrderCountUsage_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<QueryCurrentOrderCountUsage_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var trade = new SpotAccountTrade(httpClient);
+
+            var result = await trade.QueryCurrentOrderCountUsage();
+        }
+    }
+}

--- a/Examples/CSharp/SubAccount/AddIpListForASubaccountApiKey_Example.cs
+++ b/Examples/CSharp/SubAccount/AddIpListForASubaccountApiKey_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.SubAccountExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class AddIpListForASubaccountApiKey_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<AddIpListForASubaccountApiKey_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var subAccount = new SubAccount(httpClient);
+
+            var result = await subAccount.AddIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1");
+        }
+    }
+}

--- a/Examples/CSharp/SubAccount/DeleteIpListForASubaccountApiKey_Example.cs
+++ b/Examples/CSharp/SubAccount/DeleteIpListForASubaccountApiKey_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.SubAccountExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class DeleteIpListForASubaccountApiKey_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<DeleteIpListForASubaccountApiKey_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var subAccount = new SubAccount(httpClient);
+
+            var result = await subAccount.DeleteIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1");
+        }
+    }
+}

--- a/Examples/CSharp/SubAccount/EnableOrDisableIpRestrictionForASubaccountApiKey_Example.cs
+++ b/Examples/CSharp/SubAccount/EnableOrDisableIpRestrictionForASubaccountApiKey_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.SubAccountExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class EnableOrDisableIpRestrictionForASubaccountApiKey_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<EnableOrDisableIpRestrictionForASubaccountApiKey_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var subAccount = new SubAccount(httpClient);
+
+            var result = await subAccount.EnableOrDisableIpRestrictionForASubaccountApiKey("test@email", "api-key", false);
+        }
+    }
+}

--- a/Examples/CSharp/SubAccount/GetIpRestrictionForASubaccountApiKey_Example.cs
+++ b/Examples/CSharp/SubAccount/GetIpRestrictionForASubaccountApiKey_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.SubAccountExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class GetIpRestrictionForASubaccountApiKey_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<GetIpRestrictionForASubaccountApiKey_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var subAccount = new SubAccount(httpClient);
+
+            var result = await subAccount.GetIpRestrictionForASubaccountApiKey("test@email", "api-key");
+        }
+    }
+}

--- a/Examples/CSharp/UserDataWebSocket/UserDataWebSocket_Example.cs
+++ b/Examples/CSharp/UserDataWebSocket/UserDataWebSocket_Example.cs
@@ -23,8 +23,8 @@ namespace Binance.Spot.UserDataWebSocketExamples
             HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
             HttpClient httpClient = new HttpClient(handler: loggingHandler);
 
-            var apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-            var apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+            var apiKey = "api-key";
+            var apiSecret = "api-secret";
 
             var userDataStreams = new UserDataStreams(httpClient, apiKey: apiKey, apiSecret: apiSecret);
             var response = await userDataStreams.CreateSpotListenKey();

--- a/Examples/CSharp/Wallet/QueryUserUniversalTransferHistory_Example.cs
+++ b/Examples/CSharp/Wallet/QueryUserUniversalTransferHistory_Example.cs
@@ -24,7 +24,7 @@ namespace Binance.Spot.WalletExamples
 
             var wallet = new Wallet(httpClient);
 
-            var result = await wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_C2C);
+            var result = await wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_UMFUTURE);
         }
     }
 }

--- a/Examples/CSharp/Wallet/UserUniversalTransfer_Example.cs
+++ b/Examples/CSharp/Wallet/UserUniversalTransfer_Example.cs
@@ -24,7 +24,7 @@ namespace Binance.Spot.WalletExamples
 
             var wallet = new Wallet(httpClient);
 
-            var result = await wallet.UserUniversalTransfer(UniversalTransferType.MAIN_C2C, "BNB", 2.1m);
+            var result = await wallet.UserUniversalTransfer(UniversalTransferType.MAIN_UMFUTURE, "BNB", 2.1m);
         }
     }
 }

--- a/Examples/FSharp/BSwap/AddLiquidityPreview_Example.fs
+++ b/Examples/FSharp/BSwap/AddLiquidityPreview_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let bSwap = new BSwap(httpClient)
+    
+    let result = bSwap.AddLiquidityPreview(2, "SINGLE", "USDT", 1.1m) |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/BSwap/ClaimRewards_Example.fs
+++ b/Examples/FSharp/BSwap/ClaimRewards_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let bSwap = new BSwap(httpClient)
+    
+    let result = bSwap.ClaimRewards() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/BSwap/GetClaimedHistory_Example.fs
+++ b/Examples/FSharp/BSwap/GetClaimedHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let bSwap = new BSwap(httpClient)
+    
+    let result = bSwap.GetClaimedHistory() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/BSwap/GetUnclaimedRewardsRecord_Example.fs
+++ b/Examples/FSharp/BSwap/GetUnclaimedRewardsRecord_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let bSwap = new BSwap(httpClient)
+    
+    let result = bSwap.GetUnclaimedRewardsRecord() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/BSwap/PoolConfigure_Example.fs
+++ b/Examples/FSharp/BSwap/PoolConfigure_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let bSwap = new BSwap(httpClient)
+    
+    let result = bSwap.PoolConfigure() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/Convert/GetConvertTradeHistory_Example.fs
+++ b/Examples/FSharp/Convert/GetConvertTradeHistory_Example.fs
@@ -1,0 +1,23 @@
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let convert = new Convert(httpClient)
+    
+    let result = convert.GetConvertTradeHistory(1639646747000, 1642325147000) |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/CryptoLoans/GetCryptoLoansIncomeHistory_Example.fs
+++ b/Examples/FSharp/CryptoLoans/GetCryptoLoansIncomeHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let cryptoLoans = new CryptoLoans(httpClient)
+    
+    let result = cryptoLoans.GetCryptoLoansIncomeHistory("BTC") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/MarginAccountTrade/QueryCrossMarginFeeData_Example.fs
+++ b/Examples/FSharp/MarginAccountTrade/QueryCrossMarginFeeData_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let margin = new MarginAccountTrade(httpClient)
+    
+    let result = margin.QueryCrossMarginFeeData() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/MarginAccountTrade/QueryIsolatedMarginFeeData_Example.fs
+++ b/Examples/FSharp/MarginAccountTrade/QueryIsolatedMarginFeeData_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let margin = new MarginAccountTrade(httpClient)
+    
+    let result = margin.QueryIsolatedMarginFeeData() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/MarginAccountTrade/QueryIsolatedMarginTierData_Example.fs
+++ b/Examples/FSharp/MarginAccountTrade/QueryIsolatedMarginTierData_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let margin = new MarginAccountTrade(httpClient)
+    
+    let result = margin.QueryIsolatedMarginTierData("BNBUSDT") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/Mining/MiningAccountEarning_Example.fs
+++ b/Examples/FSharp/Mining/MiningAccountEarning_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let mining = new Mining(httpClient)
+    
+    let result = mining.MiningAccountEarning("sha256") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/NFT/GetNftAsset_Example.fs
+++ b/Examples/FSharp/NFT/GetNftAsset_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let nFT = new NFT(httpClient)
+    
+    let result = nFT.GetNftAsset() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/NFT/GetNftDepositHistory_Example.fs
+++ b/Examples/FSharp/NFT/GetNftDepositHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let nFT = new NFT(httpClient)
+    
+    let result = nFT.GetNftDepositHistory() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/NFT/GetNftTransactionHistory_Example.fs
+++ b/Examples/FSharp/NFT/GetNftTransactionHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let nFT = new NFT(httpClient)
+    
+    let result = nFT.GetNftTransactionHistory(1) |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/NFT/GetNftWithdrawHistory_Example.fs
+++ b/Examples/FSharp/NFT/GetNftWithdrawHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let nFT = new NFT(httpClient)
+    
+    let result = nFT.GetNftWithdrawHistory() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/Pay/GetPayTradeHistory_Example.fs
+++ b/Examples/FSharp/Pay/GetPayTradeHistory_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let pay = new Pay(httpClient)
+    
+    let result = pay.GetPayTradeHistory() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/Rebate/GetSpotRebateHistoryRecords_Example.fs
+++ b/Examples/FSharp/Rebate/GetSpotRebateHistoryRecords_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let rebate = new Rebate(httpClient)
+    
+    let result = rebate.GetSpotRebateHistoryRecords() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/SpotAccountTrade/QueryCurrentOrderCountUsage_Example.fs
+++ b/Examples/FSharp/SpotAccountTrade/QueryCurrentOrderCountUsage_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let trade = new SpotAccountTrade(httpClient)
+    
+    let result = trade.QueryCurrentOrderCountUsage() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/SubAccount/AddIpListForASubaccountApiKey_Example.fs
+++ b/Examples/FSharp/SubAccount/AddIpListForASubaccountApiKey_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let subAccount = new SubAccount(httpClient)
+    
+    let result = subAccount.AddIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/SubAccount/DeleteIpListForASubaccountApiKey_Example.fs
+++ b/Examples/FSharp/SubAccount/DeleteIpListForASubaccountApiKey_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let subAccount = new SubAccount(httpClient)
+    
+    let result = subAccount.DeleteIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/SubAccount/EnableOrDisableIpRestrictionForASubaccountApiKey_Example.fs
+++ b/Examples/FSharp/SubAccount/EnableOrDisableIpRestrictionForASubaccountApiKey_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let subAccount = new SubAccount(httpClient)
+    
+    let result = subAccount.EnableOrDisableIpRestrictionForASubaccountApiKey("test@email", "api-key", false) |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/SubAccount/GetIpRestrictionForASubaccountApiKey_Example.fs
+++ b/Examples/FSharp/SubAccount/GetIpRestrictionForASubaccountApiKey_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let subAccount = new SubAccount(httpClient)
+    
+    let result = subAccount.GetIpRestrictionForASubaccountApiKey("test@email", "api-key") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/UserDataWebSocket/UserDataWebSocket_Example.fs
+++ b/Examples/FSharp/UserDataWebSocket/UserDataWebSocket_Example.fs
@@ -19,8 +19,8 @@ let main argv =
     let loggingHandler = new BinanceLoggingHandler(logger)
     let httpClient = new HttpClient(loggingHandler)
 
-    let apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-    let apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+    let apiKey = "api-key";
+    let apiSecret = "api-secret";
     
     let userDataStreams = new UserDataStreams(httpClient, apiKey = apiKey, apiSecret = apiSecret)
     let response = userDataStreams.CreateSpotListenKey() |> Async.AwaitTask |> Async.RunSynchronously

--- a/Examples/FSharp/Wallet/QueryUserUniversalTransferHistory_Example.fs
+++ b/Examples/FSharp/Wallet/QueryUserUniversalTransferHistory_Example.fs
@@ -19,6 +19,6 @@ let main argv =
     
     let wallet = new Wallet(httpClient)
     
-    let result = wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_C2C) |> Async.AwaitTask |> Async.RunSynchronously
+    let result = wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_UMFUTURE) |> Async.AwaitTask |> Async.RunSynchronously
     
     0

--- a/Examples/FSharp/Wallet/UserUniversalTransfer_Example.fs
+++ b/Examples/FSharp/Wallet/UserUniversalTransfer_Example.fs
@@ -19,6 +19,6 @@ let main argv =
     
     let wallet = new Wallet(httpClient)
     
-    let result = wallet.UserUniversalTransfer(UniversalTransferType.MAIN_C2C, "BNB", 2.1m) |> Async.AwaitTask |> Async.RunSynchronously
+    let result = wallet.UserUniversalTransfer(UniversalTransferType.MAIN_UMFUTURE, "BNB", 2.1m) |> Async.AwaitTask |> Async.RunSynchronously
     
     0

--- a/README.md
+++ b/README.md
@@ -146,13 +146,17 @@ Wallet wallet = new Wallet(httpClient: httpClient);
 ### Exceptions
 
 There are 2 types of exceptions returned from the library:
-- `Binance.Common.BinanceClientExceptions`
+- `Binance.Common.BinanceClientException`
     - This is thrown when server returns `4XX`, it's an issue from client side.
-    - It has 2 properties:
-        - `code` - Server's error code, e.g. `-1102`
-        - `message` - Server's error message, e.g. `Unknown order sent.`
-- `Binance.Common.BinanceServerExceptions`
+    - Properties:
+        - `Code` - Server's error code, e.g. `-1102`
+        - `Message` - Server's error message, e.g. `Unknown order sent.`
+- `Binance.Common.BinanceServerException`
     - This is thrown when server returns `5XX`, it's an issue from server side.
+
+Both exceptions inherit `Binance.Common.BinanceHttpException` along with the following properties:
+- `StatusCode` - Response http status code, e.g. `401`
+- `Headers` -  Dictionary with response headers
 
 ### Logging
 This library implements the .NET logging API that works with a variety of built-in and third-party logging providers. 

--- a/Src/Common/BinanceClientException.cs
+++ b/Src/Common/BinanceClientException.cs
@@ -5,7 +5,7 @@ namespace Binance.Common
     /// <summary>
     /// Binance exception class for any errors throw as a result of the misuse of the API or the library.
     /// </summary>
-    public class BinanceClientException : Exception
+    public class BinanceClientException : BinanceHttpException
     {
         public BinanceClientException()
         : base()

--- a/Src/Common/BinanceHttpException.cs
+++ b/Src/Common/BinanceHttpException.cs
@@ -1,0 +1,30 @@
+namespace Binance.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Binance exception class for any errors throw as a result of communication via http.
+    /// </summary>
+    public class BinanceHttpException : Exception
+    {
+        public BinanceHttpException()
+        : base()
+        {
+        }
+
+        public BinanceHttpException(string message)
+        : base(message)
+        {
+        }
+
+        public BinanceHttpException(string message, Exception innerException)
+        : base(message, innerException)
+        {
+        }
+
+        public int StatusCode { get; set; }
+
+        public Dictionary<string, IEnumerable<string>> Headers { get; set; }
+    }
+}

--- a/Src/Common/BinanceServerException.cs
+++ b/Src/Common/BinanceServerException.cs
@@ -5,7 +5,7 @@ namespace Binance.Common
     /// <summary>
     /// Binance exception class for any errors throw as a result internal server issues.
     /// </summary>
-    public class BinanceServerException : Exception
+    public class BinanceServerException : BinanceHttpException
     {
         public BinanceServerException()
         : base()

--- a/Src/Common/BinanceWebSocket.cs
+++ b/Src/Common/BinanceWebSocket.cs
@@ -35,7 +35,7 @@ namespace Binance.Common
             {
                 this.loopCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 await this.handler.ConnectAsync(this.url, cancellationToken);
-                await Task.Factory.StartNew(() => this.ReceiveLoop(loopCancellationTokenSource.Token, this.receiveBufferSize), loopCancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                await Task.Factory.StartNew(() => this.ReceiveLoop(this.loopCancellationTokenSource.Token, this.receiveBufferSize), this.loopCancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
 
@@ -45,6 +45,7 @@ namespace Binance.Common
             {
                 this.loopCancellationTokenSource.Cancel();
             }
+
             if (this.handler.State == WebSocketState.Open)
             {
                 await this.handler.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, cancellationToken);
@@ -97,6 +98,7 @@ namespace Binance.Common
                     {
                         break;
                     }
+
                     string content = Encoding.UTF8.GetString(buffer.ToArray());
                     this.onMessageReceivedFunctions.ForEach(omrf => omrf(content));
                 }

--- a/Src/Spot/.nuspec
+++ b/Src/Spot/.nuspec
@@ -11,7 +11,7 @@
         <releaseNotes>CHANGELOG.md</releaseNotes>
         <readme>README.md</readme>
         <repository type="git" url="https://github.com/binance/binance-connector-dotnet" branch="master"></repository>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <authors>binance</authors>
 
         <dependencies>

--- a/Src/Spot/BSwap.cs
+++ b/Src/Spot/BSwap.cs
@@ -245,5 +245,143 @@ namespace Binance.Spot
 
             return result;
         }
+
+        private const string POOL_CONFIGURE = "/sapi/v1/bswap/poolConfigure";
+
+        /// <summary>
+        /// Weight(IP): 150.
+        /// </summary>
+        /// <param name="poolId"></param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Pool Information.</returns>
+        public async Task<string> PoolConfigure(long? poolId = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                POOL_CONFIGURE,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "poolId", poolId },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string ADD_LIQUIDITY_PREVIEW = "/sapi/v1/bswap/addLiquidityPreview";
+
+        /// <summary>
+        /// Calculate expected share amount for adding liquidity in single or dual token.<para />
+        /// Weight(IP): 150.
+        /// </summary>
+        /// <param name="poolId"></param>
+        /// <param name="type">"SINGLE" for adding a single token;"COMBINATION" for adding dual tokens.</param>
+        /// <param name="quoteAsset"></param>
+        /// <param name="quoteQty"></param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Add Liquidity Preview.</returns>
+        public async Task<string> AddLiquidityPreview(long poolId, string type, string quoteAsset, decimal quoteQty, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                ADD_LIQUIDITY_PREVIEW,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "poolId", poolId },
+                    { "type", type },
+                    { "quoteAsset", quoteAsset },
+                    { "quoteQty", quoteQty },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_UNCLAIMED_REWARDS_RECORD = "/sapi/v1/bswap/unclaimedRewards";
+
+        /// <summary>
+        /// Get unclaimed rewards record.<para />
+        ///  .<para />
+        /// Weight(UID): 1000.
+        /// </summary>
+        /// <param name="type">0: Swap rewards, 1: Liquidity rewards, default to 0.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Unclaimed rewards record.</returns>
+        public async Task<string> GetUnclaimedRewardsRecord(int? type = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_UNCLAIMED_REWARDS_RECORD,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "type", type },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string CLAIM_REWARDS = "/sapi/v1/bswap/claimRewards";
+
+        /// <summary>
+        /// Claim swap rewards or liquidity rewards.<para />
+        ///  .<para />
+        /// Weight(UID): 1000.
+        /// </summary>
+        /// <param name="type">0: Swap rewards, 1: Liquidity rewards, default to 0.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Result of claim.</returns>
+        public async Task<string> ClaimRewards(int? type = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                CLAIM_REWARDS,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "type", type },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_CLAIMED_HISTORY = "/sapi/v1/bswap/claimedHistory";
+
+        /// <summary>
+        /// Get history of claimed rewards.<para />
+        ///  .<para />
+        /// Weight(UID): 1000.
+        /// </summary>
+        /// <param name="poolId"></param>
+        /// <param name="assetRewards"></param>
+        /// <param name="type">0: Swap rewards, 1: Liquidity rewards, default to 0.</param>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">Default 3, max 100.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Claimed History.</returns>
+        public async Task<string> GetClaimedHistory(long? poolId = null, string assetRewards = null, int? type = null, long? startTime = null, long? endTime = null, int? limit = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_CLAIMED_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "poolId", poolId },
+                    { "assetRewards", assetRewards },
+                    { "type", type },
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
     }
 }

--- a/Src/Spot/Convert.cs
+++ b/Src/Spot/Convert.cs
@@ -1,0 +1,49 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class Convert : SpotService
+    {
+        public Convert(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public Convert(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string GET_CONVERT_TRADE_HISTORY = "/sapi/v1/convert/tradeFlow";
+
+        /// <summary>
+        /// - The max interval between startTime and endTime is 30 days.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">default 100, max 1000.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Convert Trade History.</returns>
+        public async Task<string> GetConvertTradeHistory(long startTime, long endTime, int? limit = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_CONVERT_TRADE_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Src/Spot/CryptoLoans.cs
+++ b/Src/Spot/CryptoLoans.cs
@@ -1,0 +1,54 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class CryptoLoans : SpotService
+    {
+        public CryptoLoans(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public CryptoLoans(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string GET_CRYPTO_LOANS_INCOME_HISTORY = "/sapi/v1/loan/income";
+
+        /// <summary>
+        /// - If startTime and endTime are not sent, the recent 7-day data will be returned.<para />
+        /// - The max interval between startTime and endTime is 30 days.<para />
+        /// Weight(UID): 6000.
+        /// </summary>
+        /// <param name="asset"></param>
+        /// <param name="type">All types will be returned by default. Enum: borrowIn, collateralSpent, repayAmount, collateralReturn (Collateral return after repayment), addCollateral, removeCollateral, collateralReturnAfterLiquidation.</param>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">default 20, max 100.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Loan History.</returns>
+        public async Task<string> GetCryptoLoansIncomeHistory(string asset, string type = null, long? startTime = null, long? endTime = null, int? limit = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_CRYPTO_LOANS_INCOME_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "asset", asset },
+                    { "type", type },
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Src/Spot/Futures.cs
+++ b/Src/Spot/Futures.cs
@@ -48,7 +48,10 @@ namespace Binance.Spot
         private const string GET_FUTURE_ACCOUNT_TRANSACTION_HISTORY_LIST = "/sapi/v1/futures/transfer";
 
         /// <summary>
-        /// Get Future Account Transaction History.
+        /// Get Future Account Transaction History.<para />
+        /// - Support query within the last 6 months only.<para />
+        /// - If `startTime` and `endTime` not sent, return records of the last 7 days by default.<para />
+        /// Weight(IP): 10.
         /// </summary>
         /// <param name="asset"></param>
         /// <param name="startTime"></param>

--- a/Src/Spot/MarginAccountTrade.cs
+++ b/Src/Spot/MarginAccountTrade.cs
@@ -1148,16 +1148,16 @@ namespace Binance.Spot
         private const string QUERY_MARGIN_INTEREST_RATE_HISTORY = "/sapi/v1/margin/interestRateHistory";
 
         /// <summary>
-        /// Weight: 1.
+        /// The max interval between startTime and endTime is 30 days.<para />
+        /// Weight(IP): 1.
         /// </summary>
         /// <param name="asset"></param>
         /// <param name="vipLevel">Defaults to user's vip level.</param>
         /// <param name="startTime">UTC timestamp in ms.</param>
         /// <param name="endTime">UTC timestamp in ms.</param>
-        /// <param name="limit">Default 500; max 1000.</param>
         /// <param name="recvWindow">The value cannot be greater than 60000.</param>
         /// <returns>Margin Interest Rate History.</returns>
-        public async Task<string> QueryMarginInterestRateHistory(string asset, int? vipLevel = null, long? startTime = null, long? endTime = null, int? limit = null, long? recvWindow = null)
+        public async Task<string> QueryMarginInterestRateHistory(string asset, int? vipLevel = null, long? startTime = null, long? endTime = null, long? recvWindow = null)
         {
             var result = await this.SendSignedAsync<string>(
                 QUERY_MARGIN_INTEREST_RATE_HISTORY,
@@ -1168,7 +1168,84 @@ namespace Binance.Spot
                     { "vipLevel", vipLevel },
                     { "startTime", startTime },
                     { "endTime", endTime },
-                    { "limit", limit },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string QUERY_CROSS_MARGIN_FEE_DATA = "/sapi/v1/margin/crossMarginData";
+
+        /// <summary>
+        /// Get cross margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee.<para />
+        /// Weight(IP): 1 when coin is specified; 5 when the coin parameter is omitted.
+        /// </summary>
+        /// <param name="vipLevel">Defaults to user's vip level.</param>
+        /// <param name="coin">Coin name.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Cross Margin Fee Data.</returns>
+        public async Task<string> QueryCrossMarginFeeData(int? vipLevel = null, string coin = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                QUERY_CROSS_MARGIN_FEE_DATA,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "vipLevel", vipLevel },
+                    { "coin", coin },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string QUERY_ISOLATED_MARGIN_FEE_DATA = "/sapi/v1/margin/isolatedMarginData";
+
+        /// <summary>
+        /// Get isolated margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee.<para />
+        /// Weight(IP): 1 when a single is specified; 10 when the symbol parameter is omitted.
+        /// </summary>
+        /// <param name="vipLevel">Defaults to user's vip level.</param>
+        /// <param name="symbol">Trading symbol, e.g. BNBUSDT.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Isolated Margin Fee Data.</returns>
+        public async Task<string> QueryIsolatedMarginFeeData(int? vipLevel = null, string symbol = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                QUERY_ISOLATED_MARGIN_FEE_DATA,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "vipLevel", vipLevel },
+                    { "symbol", symbol },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string QUERY_ISOLATED_MARGIN_TIER_DATA = "/sapi/v1/margin/isolatedMarginTier";
+
+        /// <summary>
+        /// Get isolated margin tier data collection with any tier as https://www.binance.com/en/margin-data.<para />
+        /// Weight(IP): 1.
+        /// </summary>
+        /// <param name="symbol">Trading symbol, e.g. BNBUSDT.</param>
+        /// <param name="tier">All margin tier data will be returned if tier is omitted.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Isolated Margin Tier Data.</returns>
+        public async Task<string> QueryIsolatedMarginTierData(string symbol, string tier = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                QUERY_ISOLATED_MARGIN_TIER_DATA,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "symbol", symbol },
+                    { "tier", tier },
                     { "recvWindow", recvWindow },
                     { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
                 });

--- a/Src/Spot/Mining.cs
+++ b/Src/Spot/Mining.cs
@@ -209,5 +209,36 @@ namespace Binance.Spot
 
             return result;
         }
+
+        private const string MINING_ACCOUNT_EARNING = "/sapi/v1/mining/payment/uid";
+
+        /// <summary>
+        /// Weight(IP): 5.
+        /// </summary>
+        /// <param name="algo">Algorithm(sha256).</param>
+        /// <param name="startDate">Search date, millisecond timestamp, while empty query all.</param>
+        /// <param name="endDate">Search date, millisecond timestamp, while empty query all.</param>
+        /// <param name="pageIndex">Page number, default is first page, start form 1.</param>
+        /// <param name="pageSize">Number of pages, minimum 10, maximum 200.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Mining account earnings.</returns>
+        public async Task<string> MiningAccountEarning(string algo, string startDate = null, string endDate = null, int? pageIndex = null, string pageSize = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                MINING_ACCOUNT_EARNING,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "algo", algo },
+                    { "startDate", startDate },
+                    { "endDate", endDate },
+                    { "pageIndex", pageIndex },
+                    { "pageSize", pageSize },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
     }
 }

--- a/Src/Spot/Models/UniversalTransferType.cs
+++ b/Src/Spot/Models/UniversalTransferType.cs
@@ -7,34 +7,27 @@ namespace Binance.Spot.Models
             this.Value = value;
         }
 
-        public static UniversalTransferType MAIN_C2C { get => new UniversalTransferType("MAIN_C2C"); }
         public static UniversalTransferType MAIN_UMFUTURE { get => new UniversalTransferType("MAIN_UMFUTURE"); }
         public static UniversalTransferType MAIN_CMFUTURE { get => new UniversalTransferType("MAIN_CMFUTURE"); }
         public static UniversalTransferType MAIN_MARGIN { get => new UniversalTransferType("MAIN_MARGIN"); }
-        public static UniversalTransferType MAIN_MINING { get => new UniversalTransferType("MAIN_MINING"); }
-        public static UniversalTransferType C2C_MAIN { get => new UniversalTransferType("C2C_MAIN"); }
-        public static UniversalTransferType C2C_UMFUTURE { get => new UniversalTransferType("C2C_UMFUTURE"); }
-        public static UniversalTransferType C2C_MINING { get => new UniversalTransferType("C2C_MINING"); }
-        public static UniversalTransferType C2C_MARGIN { get => new UniversalTransferType("C2C_MARGIN"); }
         public static UniversalTransferType UMFUTURE_MAIN { get => new UniversalTransferType("UMFUTURE_MAIN"); }
-        public static UniversalTransferType UMFUTURE_C2C { get => new UniversalTransferType("UMFUTURE_C2C"); }
         public static UniversalTransferType UMFUTURE_MARGIN { get => new UniversalTransferType("UMFUTURE_MARGIN"); }
         public static UniversalTransferType CMFUTURE_MAIN { get => new UniversalTransferType("CMFUTURE_MAIN"); }
         public static UniversalTransferType CMFUTURE_MARGIN { get => new UniversalTransferType("CMFUTURE_MARGIN"); }
         public static UniversalTransferType MARGIN_MAIN { get => new UniversalTransferType("MARGIN_MAIN"); }
         public static UniversalTransferType MARGIN_UMFUTURE { get => new UniversalTransferType("MARGIN_UMFUTURE"); }
         public static UniversalTransferType MARGIN_CMFUTURE { get => new UniversalTransferType("MARGIN_CMFUTURE"); }
-        public static UniversalTransferType MARGIN_MINING { get => new UniversalTransferType("MARGIN_MINING"); }
-        public static UniversalTransferType MARGIN_C2C { get => new UniversalTransferType("MARGIN_C2C"); }
-        public static UniversalTransferType MINING_MAIN { get => new UniversalTransferType("MINING_MAIN"); }
-        public static UniversalTransferType MINING_UMFUTURE { get => new UniversalTransferType("MINING_UMFUTURE"); }
-        public static UniversalTransferType MINING_C2C { get => new UniversalTransferType("MINING_C2C"); }
-        public static UniversalTransferType MINING_MARGIN { get => new UniversalTransferType("MINING_MARGIN"); }
-        public static UniversalTransferType MAIN_PAY { get => new UniversalTransferType("MAIN_PAY"); }
-        public static UniversalTransferType PAY_MAIN { get => new UniversalTransferType("PAY_MAIN"); }
         public static UniversalTransferType ISOLATEDMARGIN_MARGIN { get => new UniversalTransferType("ISOLATEDMARGIN_MARGIN"); }
         public static UniversalTransferType MARGIN_ISOLATEDMARGIN { get => new UniversalTransferType("MARGIN_ISOLATEDMARGIN"); }
         public static UniversalTransferType ISOLATEDMARGIN_ISOLATEDMARGIN { get => new UniversalTransferType("ISOLATEDMARGIN_ISOLATEDMARGIN"); }
+        public static UniversalTransferType MAIN_FUNDING { get => new UniversalTransferType("MAIN_FUNDING"); }
+        public static UniversalTransferType FUNDING_MAIN { get => new UniversalTransferType("FUNDING_MAIN"); }
+        public static UniversalTransferType FUNDING_UMFUTURE { get => new UniversalTransferType("FUNDING_UMFUTURE"); }
+        public static UniversalTransferType UMFUTURE_FUNDING { get => new UniversalTransferType("UMFUTURE_FUNDING"); }
+        public static UniversalTransferType MARGIN_FUNDING { get => new UniversalTransferType("MARGIN_FUNDING"); }
+        public static UniversalTransferType FUNDING_MARGIN { get => new UniversalTransferType("FUNDING_MARGIN"); }
+        public static UniversalTransferType FUNDING_CMFUTURE { get => new UniversalTransferType("FUNDING_CMFUTURE"); }
+        public static UniversalTransferType CMFUTURE_FUNDING { get => new UniversalTransferType("CMFUTURE_FUNDING"); }
 
         public string Value { get; private set; }
 

--- a/Src/Spot/NFT.cs
+++ b/Src/Spot/NFT.cs
@@ -1,0 +1,141 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class NFT : SpotService
+    {
+        public NFT(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public NFT(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string GET_NFT_TRANSACTION_HISTORY = "/sapi/v1/nft/history/transactions";
+
+        /// <summary>
+        /// - The max interval between startTime and endTime is 90 days.<para />
+        /// - If startTime and endTime are not sent, the recent 7 days' data will be returned.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="orderType">0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee.</param>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">Default 50, Max 50.</param>
+        /// <param name="page">Default 1.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>NFT Transaction History.</returns>
+        public async Task<string> GetNftTransactionHistory(int orderType, long? startTime = null, long? endTime = null, int? limit = null, int? page = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_NFT_TRANSACTION_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "orderType", orderType },
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "page", page },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_NFT_DEPOSIT_HISTORY = "/sapi/v1/nft/history/deposit";
+
+        /// <summary>
+        /// - The max interval between startTime and endTime is 90 days.<para />
+        /// - If startTime and endTime are not sent, the recent 7 days' data will be returned.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">Default 50, Max 50.</param>
+        /// <param name="page">Default 1.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>NFT Deposit History.</returns>
+        public async Task<string> GetNftDepositHistory(long? startTime = null, long? endTime = null, int? limit = null, int? page = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_NFT_DEPOSIT_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "page", page },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_NFT_WITHDRAW_HISTORY = "/sapi/v1/nft/history/withdraw";
+
+        /// <summary>
+        /// - The max interval between startTime and endTime is 90 days.<para />
+        /// - If startTime and endTime are not sent, the recent 7 days' data will be returned.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="limit">Default 50, Max 50.</param>
+        /// <param name="page">Default 1.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>NFT Withdraw History.</returns>
+        public async Task<string> GetNftWithdrawHistory(long? startTime = null, long? endTime = null, int? limit = null, int? page = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_NFT_WITHDRAW_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "limit", limit },
+                    { "page", page },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_NFT_ASSET = "/sapi/v1/nft/user/getAsset";
+
+        /// <summary>
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="limit">Default 50, Max 50.</param>
+        /// <param name="page">Default 1.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Asset Information.</returns>
+        public async Task<string> GetNftAsset(int? limit = null, int? page = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_NFT_ASSET,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "limit", limit },
+                    { "page", page },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Src/Spot/Pay.cs
+++ b/Src/Spot/Pay.cs
@@ -1,0 +1,51 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class Pay : SpotService
+    {
+        public Pay(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public Pay(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string GET_PAY_TRADE_HISTORY = "/sapi/v1/pay/transactions";
+
+        /// <summary>
+        /// - If startTimestamp and endTimestamp are not sent, the recent 90 days' data will be returned.<para />
+        /// - The max interval between startTimestamp and endTimestamp is 90 days.<para />
+        /// - Support for querying orders within the last 18 months.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="startTimestamp">UTC timestamp in ms.</param>
+        /// <param name="endTimestamp">UTC timestamp in ms.</param>
+        /// <param name="limit">default 100, max 100.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Pay History.</returns>
+        public async Task<string> GetPayTradeHistory(long? startTimestamp = null, long? endTimestamp = null, int? limit = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_PAY_TRADE_HISTORY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTimestamp", startTimestamp },
+                    { "endTimestamp", endTimestamp },
+                    { "limit", limit },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Src/Spot/Rebate.cs
+++ b/Src/Spot/Rebate.cs
@@ -1,0 +1,51 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class Rebate : SpotService
+    {
+        public Rebate(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public Rebate(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string GET_SPOT_REBATE_HISTORY_RECORDS = "/sapi/v1/rebate/taxQuery";
+
+        /// <summary>
+        /// - The max interval between startTime and endTime is 90 days.<para />
+        /// - If startTime and endTime are not sent, the recent 7 days' data will be returned.<para />
+        /// - The earliest startTime is supported on June 10, 2020.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="page">default 1.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Rebate History.</returns>
+        public async Task<string> GetSpotRebateHistoryRecords(long? startTime = null, long? endTime = null, int? page = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_SPOT_REBATE_HISTORY_RECORDS,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "page", page },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Src/Spot/SpotAccountTrade.cs
+++ b/Src/Spot/SpotAccountTrade.cs
@@ -458,5 +458,27 @@ namespace Binance.Spot
 
             return result;
         }
+
+        private const string QUERY_CURRENT_ORDER_COUNT_USAGE = "/api/v3/rateLimit/order";
+
+        /// <summary>
+        /// Displays the user's current order count usage for all intervals.<para />
+        /// Weight(IP): 20.
+        /// </summary>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Order rate limits.</returns>
+        public async Task<string> QueryCurrentOrderCountUsage(long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                QUERY_CURRENT_ORDER_COUNT_USAGE,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
     }
 }

--- a/Src/Spot/SubAccount.cs
+++ b/Src/Spot/SubAccount.cs
@@ -620,7 +620,7 @@ namespace Binance.Spot
         /// - Transfer from master account by default if fromEmail is not sent.<para />
         /// - Transfer to master account by default if toEmail is not sent.<para />
         /// - Transfer between futures accounts is not supported.<para />
-        /// Weight: 1.
+        /// Weight(IP): 1.
         /// </summary>
         /// <param name="fromAccountType"></param>
         /// <param name="toAccountType"></param>
@@ -628,9 +628,10 @@ namespace Binance.Spot
         /// <param name="amount"></param>
         /// <param name="fromEmail">Sub-account email.</param>
         /// <param name="toEmail">Sub-account email.</param>
+        /// <param name="clientTranId"></param>
         /// <param name="recvWindow">The value cannot be greater than 60000.</param>
         /// <returns>Transfer id.</returns>
-        public async Task<string> UniversalTransfer(UniversalTransferAccountType fromAccountType, UniversalTransferAccountType toAccountType, string asset, decimal amount, string fromEmail = null, string toEmail = null, long? recvWindow = null)
+        public async Task<string> UniversalTransfer(UniversalTransferAccountType fromAccountType, UniversalTransferAccountType toAccountType, string asset, decimal amount, string fromEmail = null, string toEmail = null, string clientTranId = null, long? recvWindow = null)
         {
             var result = await this.SendSignedAsync<string>(
                 UNIVERSAL_TRANSFER,
@@ -641,6 +642,7 @@ namespace Binance.Spot
                     { "toEmail", toEmail },
                     { "fromAccountType", fromAccountType },
                     { "toAccountType", toAccountType },
+                    { "clientTranId", clientTranId },
                     { "asset", asset },
                     { "amount", amount },
                     { "recvWindow", recvWindow },
@@ -656,7 +658,7 @@ namespace Binance.Spot
         /// - fromEmail and toEmail cannot be sent at the same time.<para />
         /// - Return fromEmail equal master account email by default.<para />
         /// - Only get the latest history of past 30 days.<para />
-        /// Weight: 1.
+        /// Weight(IP): 1.
         /// </summary>
         /// <param name="fromEmail">Sub-account email.</param>
         /// <param name="toEmail">Sub-account email.</param>
@@ -665,8 +667,9 @@ namespace Binance.Spot
         /// <param name="page">Default 1.</param>
         /// <param name="limit">Default 500, Max 500.</param>
         /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <param name="clientTranId"></param>
         /// <returns>Transfer History.</returns>
-        public async Task<string> QueryUniversalTransferHistory(string fromEmail = null, string toEmail = null, long? startTime = null, long? endTime = null, int? page = null, int? limit = null, long? recvWindow = null)
+        public async Task<string> QueryUniversalTransferHistory(string fromEmail = null, string toEmail = null, long? startTime = null, long? endTime = null, int? page = null, int? limit = null, long? recvWindow = null, string clientTranId = null)
         {
             var result = await this.SendSignedAsync<string>(
                 QUERY_UNIVERSAL_TRANSFER_HISTORY,
@@ -675,6 +678,7 @@ namespace Binance.Spot
                 {
                     { "fromEmail", fromEmail },
                     { "toEmail", toEmail },
+                    { "clientTranId", clientTranId },
                     { "startTime", startTime },
                     { "endTime", endTime },
                     { "page", page },
@@ -863,6 +867,113 @@ namespace Binance.Spot
                     { "asset", asset },
                     { "amount", amount },
                     { "transferDate", transferDate },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string ENABLE_OR_DISABLE_IP_RESTRICTION_FOR_A_SUBACCOUNT_API_KEY = "/sapi/v1/sub-account/subAccountApi/ipRestriction";
+
+        /// <summary>
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="email">Sub-account email.</param>
+        /// <param name="subAccountApiKey"></param>
+        /// <param name="ipRestrict">true or false.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>IP Restriction information.</returns>
+        public async Task<string> EnableOrDisableIpRestrictionForASubaccountApiKey(string email, string subAccountApiKey, bool ipRestrict, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                ENABLE_OR_DISABLE_IP_RESTRICTION_FOR_A_SUBACCOUNT_API_KEY,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "email", email },
+                    { "subAccountApiKey", subAccountApiKey },
+                    { "ipRestrict", ipRestrict },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string GET_IP_RESTRICTION_FOR_A_SUBACCOUNT_API_KEY = "/sapi/v1/sub-account/subAccountApi/ipRestriction";
+
+        /// <summary>
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="email">Sub-account email.</param>
+        /// <param name="subAccountApiKey"></param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>IP Restriction information.</returns>
+        public async Task<string> GetIpRestrictionForASubaccountApiKey(string email, string subAccountApiKey, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                GET_IP_RESTRICTION_FOR_A_SUBACCOUNT_API_KEY,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "email", email },
+                    { "subAccountApiKey", subAccountApiKey },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string ADD_IP_LIST_FOR_A_SUBACCOUNT_API_KEY = "/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList";
+
+        /// <summary>
+        /// Before the usage of this endpoint, please ensure `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` was used to enable the IP restriction.<para />
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="email">Sub-account email.</param>
+        /// <param name="subAccountApiKey"></param>
+        /// <param name="ipAddress">Can be added in batches, separated by commas.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Add IP information.</returns>
+        public async Task<string> AddIpListForASubaccountApiKey(string email, string subAccountApiKey, string ipAddress, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                ADD_IP_LIST_FOR_A_SUBACCOUNT_API_KEY,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "email", email },
+                    { "subAccountApiKey", subAccountApiKey },
+                    { "ipAddress", ipAddress },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string DELETE_IP_LIST_FOR_A_SUBACCOUNT_API_KEY = "/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList";
+
+        /// <summary>
+        /// Weight(UID): 3000.
+        /// </summary>
+        /// <param name="email">Sub-account email.</param>
+        /// <param name="subAccountApiKey"></param>
+        /// <param name="ipAddress">Can be added in batches, separated by commas.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Delete IP information.</returns>
+        public async Task<string> DeleteIpListForASubaccountApiKey(string email, string subAccountApiKey, string ipAddress, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                DELETE_IP_LIST_FOR_A_SUBACCOUNT_API_KEY,
+                HttpMethod.Delete,
+                query: new Dictionary<string, object>
+                {
+                    { "email", email },
+                    { "subAccountApiKey", subAccountApiKey },
+                    { "ipAddress", ipAddress },
                     { "recvWindow", recvWindow },
                     { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
                 });

--- a/Src/Spot/Wallet.cs
+++ b/Src/Spot/Wallet.cs
@@ -59,7 +59,10 @@ namespace Binance.Spot
         private const string DAILY_ACCOUNT_SNAPSHOT = "/sapi/v1/accountSnapshot";
 
         /// <summary>
-        /// Weight: 1.
+        /// - The query time period must be less than 30 days.<para />
+        /// - Support query within the last 6 months only.<para />
+        /// - If startTimeand endTime not sent, return records of the last 7 days by default.<para />
+        /// Weight(IP): 2400.
         /// </summary>
         /// <param name="type"></param>
         /// <param name="startTime">UTC timestamp in ms.</param>
@@ -147,9 +150,10 @@ namespace Binance.Spot
         /// - `true` ->  returning the fee to the destination account;.<para />
         /// - `false` -> returning the fee back to the departure account.</param>
         /// <param name="name"></param>
+        /// <param name="walletType">The wallet type for withdraw，0-Spot wallet, 1- Funding wallet. Default is Spot wallet.</param>
         /// <param name="recvWindow">The value cannot be greater than 60000.</param>
         /// <returns>Transafer Id.</returns>
-        public async Task<string> Withdraw(string coin, string address, decimal amount, string withdrawOrderId = null, string network = null, string addressTag = null, bool? transactionFeeFlag = null, string name = null, long? recvWindow = null)
+        public async Task<string> Withdraw(string coin, string address, decimal amount, string withdrawOrderId = null, string network = null, string addressTag = null, bool? transactionFeeFlag = null, string name = null, int? walletType = null, long? recvWindow = null)
         {
             var result = await this.SendSignedAsync<string>(
                 WITHDRAW,
@@ -164,6 +168,7 @@ namespace Binance.Spot
                     { "amount", amount },
                     { "transactionFeeFlag", transactionFeeFlag },
                     { "name", name },
+                    { "walletType", walletType },
                     { "recvWindow", recvWindow },
                     { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
                 });
@@ -461,35 +466,28 @@ namespace Binance.Spot
         /// - `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN.<para />
         /// - `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN.<para />
         /// ENUM of transfer types:.<para />
-        /// - MAIN_C2C Spot account transfer to C2C account.<para />
         /// - MAIN_UMFUTURE Spot account transfer to USDⓈ-M Futures account.<para />
         /// - MAIN_CMFUTURE Spot account transfer to COIN-M Futures account.<para />
         /// - MAIN_MARGIN Spot account transfer to Margin（cross）account.<para />
-        /// - MAIN_MINING Spot account transfer to Mining account.<para />
-        /// - C2C_MAIN C2C account transfer to Spot account.<para />
-        /// - C2C_UMFUTURE C2C account transfer to USDⓈ-M Futures account.<para />
-        /// - C2C_MINING C2C account transfer to Mining account.<para />
-        /// - C2C_MARGIN C2C account transfer to Margin(cross) account.<para />
         /// - UMFUTURE_MAIN USDⓈ-M Futures account transfer to Spot account.<para />
-        /// - UMFUTURE_C2C USDⓈ-M Futures account transfer to C2C account.<para />
         /// - UMFUTURE_MARGIN USDⓈ-M Futures account transfer to Margin（cross）account.<para />
         /// - CMFUTURE_MAIN COIN-M Futures account transfer to Spot account.<para />
         /// - CMFUTURE_MARGIN COIN-M Futures account transfer to Margin(cross) account.<para />
         /// - MARGIN_MAIN Margin（cross）account transfer to Spot account.<para />
         /// - MARGIN_UMFUTURE Margin（cross）account transfer to USDⓈ-M Futures.<para />
         /// - MARGIN_CMFUTURE Margin（cross）account transfer to COIN-M Futures.<para />
-        /// - MARGIN_MINING Margin（cross）account transfer to Mining account.<para />
-        /// - MARGIN_C2C Margin（cross）account transfer to C2C account.<para />
-        /// - MINING_MAIN Mining account transfer to Spot account.<para />
-        /// - MINING_UMFUTURE Mining account transfer to USDⓈ-M Futures account.<para />
-        /// - MINING_C2C Mining account transfer to C2C account.<para />
-        /// - MINING_MARGIN Mining account transfer to Margin(cross) account.<para />
-        /// - MAIN_PAY Spot account transfer to Pay account.<para />
-        /// - PAY_MAIN Pay account transfer to Spot account.<para />
         /// - ISOLATEDMARGIN_MARGIN Isolated margin account transfer to Margin(cross) account.<para />
         /// - MARGIN_ISOLATEDMARGIN Margin(cross) account transfer to Isolated margin account.<para />
         /// - ISOLATEDMARGIN_ISOLATEDMARGIN Isolated margin account transfer to Isolated margin account.<para />
-        /// Weight: 1.
+        /// - MAIN_FUNDING Spot account transfer to Funding account.<para />
+        /// - FUNDING_MAIN Funding account transfer to Spot account.<para />
+        /// - FUNDING_UMFUTURE Funding account transfer to UMFUTURE account.<para />
+        /// - UMFUTURE_FUNDING UMFUTURE account transfer to Funding account.<para />
+        /// - MARGIN_FUNDING MARGIN account transfer to Funding account.<para />
+        /// - FUNDING_MARGIN Funding account transfer to Margin account.<para />
+        /// - FUNDING_CMFUTURE Funding account transfer to CMFUTURE account.<para />
+        /// - CMFUTURE_FUNDING CMFUTURE account transfer to Funding account.<para />
+        /// Weight(IP): 1.
         /// </summary>
         /// <param name="type">Universal transfer type.</param>
         /// <param name="asset"></param>
@@ -522,7 +520,9 @@ namespace Binance.Spot
         /// <summary>
         /// - `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN.<para />
         /// - `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN.<para />
-        /// Weight: 1.
+        /// - Support query within the last 6 months only.<para />
+        /// - If `startTime` and `endTime` not sent, return records of the last 7 days by default.<para />
+        /// Weight(IP): 1.
         /// </summary>
         /// <param name="type">Universal transfer type.</param>
         /// <param name="startTime">UTC timestamp in ms.</param>

--- a/Tests/Common.Tests/BinanceService_Tests.cs
+++ b/Tests/Common.Tests/BinanceService_Tests.cs
@@ -2,6 +2,7 @@ namespace Binance.Common.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
@@ -120,13 +121,21 @@ namespace Binance.Common.Tests
         public async void SendPublicAsync_Server_Formatted_Unauthorized_Error_Throws_BinanceClientException()
         {
             var mockMessageHandler = new Mock<HttpMessageHandler>();
+
+            var content = "{\"code\":1234,\"msg\":\"Message\"}";
+            var headerKey = "Test-Header";
+            var headerValue = "Test-Value";
+
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new StringContent(content),
+            };
+            response.Headers.Add(headerKey, headerValue);
+
             mockMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.Unauthorized,
-                    Content = new StringContent("{\"code\":1234,\"msg\":\"Message\"}"),
-                });
+                .ReturnsAsync(response);
             var binanceService = new MockBinanceService(new HttpClient(mockMessageHandler.Object), baseUrl: "https://www.binance.com");
 
             var exception = await Assert.ThrowsAsync<BinanceClientException>(async () =>
@@ -136,6 +145,9 @@ namespace Binance.Common.Tests
 
             Assert.Equal(1234, exception.Code);
             Assert.Equal("Message", exception.Message);
+            Assert.Equal((int)HttpStatusCode.Unauthorized, exception.StatusCode);
+            Assert.True(exception.Headers.ContainsKey(headerKey));
+            Assert.Equal(headerValue, exception.Headers[headerKey].First());
         }
 
         [Fact]
@@ -274,12 +286,12 @@ namespace Binance.Common.Tests
         {
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             mockMessageHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(rm => rm.RequestUri.Query.Contains("signature=c8db56825ae71d6d79447849e617115f4a920fa2acdcab2b053c4b2838bd6b71")), ItExpr.IsAny<CancellationToken>())
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(rm => rm.RequestUri.Query.Contains("signature=dd3bf7fbce9c8dce2cf94b63f2f4973e62c938597734a4e08390a69ad513097e")), ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
                 });
-            var binanceService = new MockBinanceService(new HttpClient(mockMessageHandler.Object), baseUrl: "https://www.binance.com", apiKey: "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A", apiSecret: "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j");
+            var binanceService = new MockBinanceService(new HttpClient(mockMessageHandler.Object), baseUrl: "https://www.binance.com", apiKey: "api-key", apiSecret: "api-secret");
 
             await binanceService.SendSignedAsync<string>(
                 string.Empty,
@@ -400,13 +412,21 @@ namespace Binance.Common.Tests
         public async void SendSignedAsync_Server_Unformatted_Unauthorized_Error_Throws_BinanceClientException()
         {
             var mockMessageHandler = new Mock<HttpMessageHandler>();
+
+            var content = "hello";
+            var headerKey = "Test-Header";
+            var headerValue = "Test-Value";
+
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new StringContent(content),
+            };
+            response.Headers.Add(headerKey, headerValue);
+
             mockMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.Unauthorized,
-                    Content = new StringContent("hello"),
-                });
+                .ReturnsAsync(response);
             var binanceService = new MockBinanceService(new HttpClient(mockMessageHandler.Object), baseUrl: "https://www.binance.com", apiKey: null, apiSecret: "apiSecret");
 
             var exception = await Assert.ThrowsAsync<BinanceClientException>(async () =>
@@ -415,20 +435,31 @@ namespace Binance.Common.Tests
             });
 
             Assert.Equal(-1, exception.Code);
-            Assert.Equal("hello", exception.Message);
+            Assert.Equal(content, exception.Message);
+            Assert.Equal((int)HttpStatusCode.Unauthorized, exception.StatusCode);
+            Assert.True(exception.Headers.ContainsKey(headerKey));
+            Assert.Equal(headerValue, exception.Headers[headerKey].First());
         }
 
         [Fact]
         public async void SendSignedAsync_Server_Formatted_Unauthorized_Error_Throws_BinanceClientException()
         {
             var mockMessageHandler = new Mock<HttpMessageHandler>();
+
+            var content = "{\"code\":1234,\"msg\":\"Message\"}";
+            var headerKey = "Test-Header";
+            var headerValue = "Test-Value";
+
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new StringContent(content),
+            };
+            response.Headers.Add(headerKey, headerValue);
+
             mockMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.Unauthorized,
-                    Content = new StringContent("{\"code\":1234,\"msg\":\"Message\"}"),
-                });
+                .ReturnsAsync(response);
             var binanceService = new MockBinanceService(new HttpClient(mockMessageHandler.Object), baseUrl: "https://www.binance.com", apiKey: null, apiSecret: "apiSecret");
 
             var exception = await Assert.ThrowsAsync<BinanceClientException>(async () =>
@@ -438,6 +469,9 @@ namespace Binance.Common.Tests
 
             Assert.Equal(1234, exception.Code);
             Assert.Equal("Message", exception.Message);
+            Assert.Equal((int)HttpStatusCode.Unauthorized, exception.StatusCode);
+            Assert.True(exception.Headers.ContainsKey(headerKey));
+            Assert.Equal(headerValue, exception.Headers[headerKey].First());
         }
 
         [Fact]

--- a/Tests/Spot.Tests/BLVT_Tests.cs
+++ b/Tests/Spot.Tests/BLVT_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class BLVT_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region GetBlvtInfo
         [Fact]

--- a/Tests/Spot.Tests/BSwap_Tests.cs
+++ b/Tests/Spot.Tests/BSwap_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class BSwap_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region ListAllSwapPools
         [Fact]
@@ -200,6 +200,126 @@ namespace Binance.Spot.Tests
                 apiSecret: this.apiSecret);
 
             var result = await bSwap.GetSwapHistory();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region PoolConfigure
+        [Fact]
+        public async void PoolConfigure_Response()
+        {
+            var responseContent = "[{\"poolId\":2,\"poolNmae\":\"BUSD/USDT\",\"updateTime\":1565769342148,\"liquidity\":{\"constantA\":2000,\"minRedeemShare\":0.1,\"slippageTolerance\":0.2},\"assetConfigure\":{\"BUSD\":{\"minAdd\":10,\"maxAdd\":20,\"minSwap\":10,\"maxSwap\":30},\"USDT\":{\"minAdd\":10,\"maxAdd\":20,\"minSwap\":10,\"maxSwap\":30}}}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/bswap/poolConfigure", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            BSwap bSwap = new BSwap(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await bSwap.PoolConfigure();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region AddLiquidityPreview
+        [Fact]
+        public async void AddLiquidityPreview_Response()
+        {
+            var responseContent = "{\"quoteAsset\":\"USDT\",\"baseAsset\":\"BUSD\",\"quoteAmt\":300000,\"baseAmt\":299975,\"price\":1.00008334,\"share\":1.23}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/bswap/addLiquidityPreview", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            BSwap bSwap = new BSwap(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await bSwap.AddLiquidityPreview(2, "SINGLE", "USDT", 1.1m);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetUnclaimedRewardsRecord
+        [Fact]
+        public async void GetUnclaimedRewardsRecord_Response()
+        {
+            var responseContent = "{\"totalUnclaimedRewards\":{\"BUSD\":100000315.79,\"BNB\":1e-8,\"USDT\":2e-8},\"details\":{\"BNB/USDT\":{\"BUSD\":100000315.79,\"USDT\":2e-8},\"BNB/BTC\":{\"BNB\":1e-8}}}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/bswap/unclaimedRewards", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            BSwap bSwap = new BSwap(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await bSwap.GetUnclaimedRewardsRecord();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region ClaimRewards
+        [Fact]
+        public async void ClaimRewards_Response()
+        {
+            var responseContent = "{\"success\":true}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/bswap/claimRewards", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            BSwap bSwap = new BSwap(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await bSwap.ClaimRewards();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetClaimedHistory
+        [Fact]
+        public async void GetClaimedHistory_Response()
+        {
+            var responseContent = "[{\"poolId\":52,\"poolName\":\"BNB/USDT\",\"assetRewards\":\"BNB\",\"claimTime\":1565769342148,\"claimAmount\":2.3e-7,\"status\":1}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/bswap/claimedHistory", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            BSwap bSwap = new BSwap(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await bSwap.GetClaimedHistory();
 
             Assert.Equal(responseContent, result);
         }

--- a/Tests/Spot.Tests/C2C_Tests.cs
+++ b/Tests/Spot.Tests/C2C_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class C2C_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region GetC2cTradeHistory
         [Fact]

--- a/Tests/Spot.Tests/Convert_Tests.cs
+++ b/Tests/Spot.Tests/Convert_Tests.cs
@@ -1,0 +1,39 @@
+namespace Binance.Spot.Tests
+{
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class Convert_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region GetConvertTradeHistory
+        [Fact]
+        public async void GetConvertTradeHistory_Response()
+        {
+            var responseContent = "{\"list\":[{\"quoteId\":\"f3b91c525b2644c7bc1e1cd31b6e1aa6\",\"orderId\":940708407462087200,\"orderStatus\":\"SUCCESS\",\"fromAsset\":\"USDT\",\"fromAmount\":\"20\",\"toAsset\":\"BNB\",\"toAmount\":\"0.06154036\",\"ratio\":\"0.00307702\",\"inverseRatio\":\"324.99\",\"createTime\":1624248872184}],\"startTime\":1623824139000,\"endTime\":1626416139000,\"limit\":100,\"moreData\":false}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/convert/tradeFlow", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            Convert convert = new Convert(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await convert.GetConvertTradeHistory(1639646747000, 1642325147000);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}

--- a/Tests/Spot.Tests/CryptoLoans_Tests.cs
+++ b/Tests/Spot.Tests/CryptoLoans_Tests.cs
@@ -1,0 +1,40 @@
+namespace Binance.Spot.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class CryptoLoans_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region GetCryptoLoansIncomeHistory
+        [Fact]
+        public async void GetCryptoLoansIncomeHistory_Response()
+        {
+            var responseContent = "[{\"asset\":\"BUSD\",\"type\":\"borrowIn\",\"amount\":\"100\",\"timestamp\":1633771139847,\"tranId\":\"80423589583\"}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/loan/income", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            CryptoLoans cryptoLoans = new CryptoLoans(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await cryptoLoans.GetCryptoLoansIncomeHistory("BTC");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}

--- a/Tests/Spot.Tests/Fiat_Tests.cs
+++ b/Tests/Spot.Tests/Fiat_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Fiat_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region GetFiatDepositWithdrawHistory
         [Fact]

--- a/Tests/Spot.Tests/Futures_Tests.cs
+++ b/Tests/Spot.Tests/Futures_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Futures_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region NewFutureAccountTransfer
         [Fact]

--- a/Tests/Spot.Tests/MarginAccountTrade_Tests.cs
+++ b/Tests/Spot.Tests/MarginAccountTrade_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class MarginAccountTrade_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region CrossMarginAccountTransfer
         [Fact]
@@ -944,6 +944,78 @@ namespace Binance.Spot.Tests
                 apiSecret: this.apiSecret);
 
             var result = await marginAccountTrade.QueryMarginInterestRateHistory("BTC");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region QueryCrossMarginFeeData
+        [Fact]
+        public async void QueryCrossMarginFeeData_Response()
+        {
+            var responseContent = "[{\"vipLevel\":0,\"coin\":\"BTC\",\"transferIn\":true,\"borrowable\":true,\"dailyInterest\":\"0.00026125\",\"yearlyInterest\":\"0.0953\",\"borrowLimit\":\"180\",\"marginablePairs\":[\"\"]}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/margin/crossMarginData", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            MarginAccountTrade margin = new MarginAccountTrade(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await margin.QueryCrossMarginFeeData();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region QueryIsolatedMarginFeeData
+        [Fact]
+        public async void QueryIsolatedMarginFeeData_Response()
+        {
+            var responseContent = "[{\"vipLevel\":0,\"symbol\":\"BTCUSDT\",\"leverage\":\"10\",\"data\":[{\"coin\":\"\",\"dailyInterest\":\"\",\"borrowLimit\":\"\"}]}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/margin/isolatedMarginData", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            MarginAccountTrade margin = new MarginAccountTrade(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await margin.QueryIsolatedMarginFeeData();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region QueryIsolatedMarginTierData
+        [Fact]
+        public async void QueryIsolatedMarginTierData_Response()
+        {
+            var responseContent = "[{\"symbol\":\"BTCUSDT\",\"tier\":1,\"effectiveMultiple\":\"10\",\"initialRiskRatio\":\"1.111\",\"liquidationRiskRatio\":\"1.05\",\"baseAssetMaxBorrowable\":\"9\",\"quoteAssetMaxBorrowable\":\"70000\"}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/margin/isolatedMarginTier", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            MarginAccountTrade margin = new MarginAccountTrade(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await margin.QueryIsolatedMarginTierData("BNBUSDT");
 
             Assert.Equal(responseContent, result);
         }

--- a/Tests/Spot.Tests/Market_Tests.cs
+++ b/Tests/Spot.Tests/Market_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Market_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region TestConnectivity
         [Fact]

--- a/Tests/Spot.Tests/Mining_Tests.cs
+++ b/Tests/Spot.Tests/Mining_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Mining_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region AcquiringAlgorithm
         [Fact]
@@ -296,6 +296,30 @@ namespace Binance.Spot.Tests
                 apiSecret: this.apiSecret);
 
             var result = await mining.AccountList();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region MiningAccountEarning
+        [Fact]
+        public async void MiningAccountEarning_Response()
+        {
+            var responseContent = "{\"code\":0,\"msg\":\"\",\"data\":{\"accountProfits\":[{\"time\":1607443200000,\"coinName\":\"BTC\",\"type\":2,\"puid\":59985472,\"subName\":\"vdvaghani\",\"amount\":0.09186957}],\"totalNum\":3,\"pageSize\":20}}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/mining/payment/uid", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            Mining mining = new Mining(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await mining.MiningAccountEarning("sha256");
 
             Assert.Equal(responseContent, result);
         }

--- a/Tests/Spot.Tests/Models/UniversalTransferType_Tests.cs
+++ b/Tests/Spot.Tests/Models/UniversalTransferType_Tests.cs
@@ -8,7 +8,7 @@ namespace Binance.Spot.Tests
         [Fact]
         public void ToString_Matches_Value()
         {
-            var model = UniversalTransferType.MAIN_C2C;
+            var model = UniversalTransferType.MAIN_UMFUTURE;
 
             Assert.Equal(model.Value.ToString(), model.ToString());
         }

--- a/Tests/Spot.Tests/NFT_Tests.cs
+++ b/Tests/Spot.Tests/NFT_Tests.cs
@@ -1,0 +1,112 @@
+namespace Binance.Spot.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class NFT_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region GetNftTransactionHistory
+        [Fact]
+        public async void GetNftTransactionHistory_Response()
+        {
+            var responseContent = "{\"total\":1,\"list\":[{\"orderNo\":\"1_470502070600699904\",\"tokens\":[{\"network\":\"BSC\",\"tokenId\":\"216000000496\",\"contractAddress\":\"MYSTERY_BOX0000087\"}],\"tradeTime\":1626941236000,\"tradeAmount\":\"19.60000000\",\"tradeCurrency\":\"BNB\"}]}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/nft/history/transactions", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            NFT nFT = new NFT(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await nFT.GetNftTransactionHistory(1);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetNftDepositHistory
+        [Fact]
+        public async void GetNftDepositHistory_Response()
+        {
+            var responseContent = "{\"total\":1,\"list\":[{\"network\":\"ETH\",\"txID\":0,\"contractAdrress\":\"0xe507c961ee127d4439977a61af39c34eafee0dc6\",\"tokenId\":\"10014\",\"timestamp\":1629986047000}]}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/nft/history/deposit", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            NFT nFT = new NFT(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await nFT.GetNftDepositHistory();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetNftWithdrawHistory
+        [Fact]
+        public async void GetNftWithdrawHistory_Response()
+        {
+            var responseContent = "{\"total\":178,\"list\":[{\"network\":\"ETH\",\"txID\":\"0x2be5eed31d787fdb4880bc631c8e76bdfb6150e137f5cf1732e0416ea206f57f\",\"contractAdrress\":\"0xe507c961ee127d4439977a61af39c34eafee0dc6\",\"tokenId\":\"1000001247\",\"timestamp\":1633674433000,\"fee\":0.1,\"feeAsset\":\"ETH\"}]}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/nft/history/withdraw", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            NFT nFT = new NFT(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await nFT.GetNftWithdrawHistory();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetNftAsset
+        [Fact]
+        public async void GetNftAsset_Response()
+        {
+            var responseContent = "{\"total\":347,\"list\":[{\"network\":\"BSC\",\"contractAddress\":\"REGULAR11234567891779\",\"tokenId\":\"100900000017\"}]}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/nft/user/getAsset", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            NFT nFT = new NFT(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await nFT.GetNftAsset();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}

--- a/Tests/Spot.Tests/Pay_Tests.cs
+++ b/Tests/Spot.Tests/Pay_Tests.cs
@@ -1,0 +1,40 @@
+namespace Binance.Spot.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class Pay_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region GetPayTradeHistory
+        [Fact]
+        public async void GetPayTradeHistory_Response()
+        {
+            var responseContent = "{\"code\":\"000000\",\"message\":\"success\",\"data\":[{\"orderType\":\"C2C\",\"transactionId\":\"M_P_71505104267788288\",\"transactionTime\":1610090460133,\"amount\":\"23.72469206\",\"currency\":\"BNB\",\"fundsDetail\":[{\"currency\":\"\",\"amount\":\"\"}]}],\"success\":true}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/pay/transactions", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            Pay pay = new Pay(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await pay.GetPayTradeHistory();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}

--- a/Tests/Spot.Tests/Rebate_Tests.cs
+++ b/Tests/Spot.Tests/Rebate_Tests.cs
@@ -1,0 +1,40 @@
+namespace Binance.Spot.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class Rebate_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region GetSpotRebateHistoryRecords
+        [Fact]
+        public async void GetSpotRebateHistoryRecords_Response()
+        {
+            var responseContent = "{\"status\":\"OK\",\"type\":\"GENERAL\",\"code\":\"000000000\",\"data\":{\"page\":1,\"totalRecords\":2,\"totalPageNum\":1,\"data\":[{\"asset\":\"USDT\",\"type\":1,\"amount\":\"0.0001126\",\"updateTime\":1637651320000}]}}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/rebate/taxQuery", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            Rebate rebate = new Rebate(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await rebate.GetSpotRebateHistoryRecords();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}

--- a/Tests/Spot.Tests/Savings_Tests.cs
+++ b/Tests/Spot.Tests/Savings_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Savings_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region GetFlexibleProductList
         [Fact]

--- a/Tests/Spot.Tests/SpotAccountTrade_Tests.cs
+++ b/Tests/Spot.Tests/SpotAccountTrade_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class SpotAccountTrade_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region TestNewOrder
         [Fact]
@@ -344,6 +344,30 @@ namespace Binance.Spot.Tests
                 apiSecret: this.apiSecret);
 
             var result = await spotAccountTrade.AccountTradeList("BNBBTC");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region QueryCurrentOrderCountUsage
+        [Fact]
+        public async void QueryCurrentOrderCountUsage_Response()
+        {
+            var responseContent = "[{\"rateLimitType\":\"\",\"interval\":\"\",\"intervalNum\":0,\"limit\":0,\"count\":0}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/api/v3/rateLimit/order", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            SpotAccountTrade trade = new SpotAccountTrade(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await trade.QueryCurrentOrderCountUsage();
 
             Assert.Equal(responseContent, result);
         }

--- a/Tests/Spot.Tests/SubAccount_Tests.cs
+++ b/Tests/Spot.Tests/SubAccount_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class SubAccount_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region CreateAVirtualSubaccount
         [Fact]
@@ -752,6 +752,102 @@ namespace Binance.Spot.Tests
                 apiSecret: this.apiSecret);
 
             var result = await subAccount.WithdrawlAssetsFromTheManagedSubaccount("aaa@test.com", "USDT", 522.23m);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region EnableOrDisableIpRestrictionForASubaccountApiKey
+        [Fact]
+        public async void EnableOrDisableIpRestrictionForASubaccountApiKey_Response()
+        {
+            var responseContent = "{\"ipRestrict\":\"true\",\"ipList\":[\"0.0.0.0\"],\"updateTime\":1636369557189,\"apiKey\":\"apikey\"}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/sub-account/subAccountApi/ipRestriction", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            SubAccount subAccount = new SubAccount(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await subAccount.EnableOrDisableIpRestrictionForASubaccountApiKey("test@email", "api-key", false);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region GetIpRestrictionForASubaccountApiKey
+        [Fact]
+        public async void GetIpRestrictionForASubaccountApiKey_Response()
+        {
+            var responseContent = "{\"ipRestrict\":\"true\",\"ipList\":[\"\"],\"updateTime\":1636369557189,\"apiKey\":\"api-key\"}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/sub-account/subAccountApi/ipRestriction", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            SubAccount subAccount = new SubAccount(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await subAccount.GetIpRestrictionForASubaccountApiKey("test@email", "api-key");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region AddIpListForASubaccountApiKey
+        [Fact]
+        public async void AddIpListForASubaccountApiKey_Response()
+        {
+            var responseContent = "{\"ip\":\"192.168.1.20\",\"updateTime\":1636369557189,\"apiKey\":\"api-key\"}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            SubAccount subAccount = new SubAccount(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await subAccount.AddIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region DeleteIpListForASubaccountApiKey
+        [Fact]
+        public async void DeleteIpListForASubaccountApiKey_Response()
+        {
+            var responseContent = "{\"ipRestrict\":\"true\",\"ipList\":[\"\"],\"updateTime\":1636369557189,\"apiKey\":\"api-key\"}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList", HttpMethod.Delete)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            SubAccount subAccount = new SubAccount(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await subAccount.DeleteIpListForASubaccountApiKey("test@email", "api-key", "1.1.1.1");
 
             Assert.Equal(responseContent, result);
         }

--- a/Tests/Spot.Tests/UserDataStreams_Tests.cs
+++ b/Tests/Spot.Tests/UserDataStreams_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class UserDataStreams_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region CreateSpotListenKey
         [Fact]

--- a/Tests/Spot.Tests/Wallet_Tests.cs
+++ b/Tests/Spot.Tests/Wallet_Tests.cs
@@ -10,8 +10,8 @@ namespace Binance.Spot.Tests
 
     public class Wallet_Tests
     {
-        private string apiKey = "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A";
-        private string apiSecret = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j";
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
 
         #region SystemStatus
         [Fact]
@@ -415,7 +415,7 @@ namespace Binance.Spot.Tests
                 apiKey: this.apiKey,
                 apiSecret: this.apiSecret);
 
-            var result = await wallet.UserUniversalTransfer(UniversalTransferType.MAIN_C2C, "BNB", 2.1m);
+            var result = await wallet.UserUniversalTransfer(UniversalTransferType.MAIN_UMFUTURE, "BNB", 2.1m);
 
             Assert.Equal(responseContent, result);
         }
@@ -439,7 +439,7 @@ namespace Binance.Spot.Tests
                 apiKey: this.apiKey,
                 apiSecret: this.apiSecret);
 
-            var result = await wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_C2C);
+            var result = await wallet.QueryUserUniversalTransferHistory(UniversalTransferType.MAIN_UMFUTURE);
 
             Assert.Equal(responseContent, result);
         }


### PR DESCRIPTION
### Added
- New endpoints for BSwap
GET /sapi/v1/bswap/poolConfigure to get pool configure
GET /sapi/v1/bswap/addLiquidityPreview to get add liquidity preview
GET /sapi/v1/margin/isolated/accountLimit to get remove liquidity preview
GET /sapi/v1/bswap/unclaimedRewards to get unclaimed rewards record.
POST /sapi/v1/bswap/claimRewards to claim swap rewards or liquidity rewards.
GET /sapi/v1/bswap/claimedHistory to get history of claimed rewards.

- New endpoints for Trade:
GET api/v3/rateLimit/order added

- New endpoint for Crypto Loans
GET /sapi/v1/loan/income

- New endpoint for Pay
GET /sapi/v1/pay/transactions to support user query Pay trade history

- New endpoint for Convert
GET /sapi/v1/convert/tradeFlow to support user query convert trade history records

- New endpoint for Rebate
GET /sapi/v1/rebate/taxQuery to support user query spot rebate history records

- New endpoint for Margin
GET /sapi/v1/margin/crossMarginData to get cross margin fee data collection
GET /sapi/v1/margin/isolatedMarginData to get isolated margin fee data collection
GET /sapi/v1/margin/isolatedMarginTier to get isolated margin tier data collection

- New endpoints for NFT
GET /sapi/v1/nft/history/transactions to get NFT transaction history
GET /sapi/v1/nft/history/deposit to get NFT deposit history
GET /sapi/v1/nft/history/withdraw to get NFT withdraw history
GET /sapi/v1/nft/user/getAsset to get NFT asset

- New endpoint for Mining
GET /sapi/v1/mining/payment/uid to get Mining account earning.

- New endpoints for Sub-Account
POST /sapi/v1/sub-account/subAccountApi/ipRestriction to support master account enable and disable IP restriction for a sub-account API Key
POST /sapi/v1/sub-account/subAccountApi/ipRestriction/ipList to support master account add IP list for a sub-account API Key
GET /sapi/v1/account/apiRestrictions/ipRestriction to support master account query IP restriction for a sub-account API Key
DELETE /sapi/v1/account/apiRestrictions/ipRestriction/ipList to support master account delete IP list for a sub-account API Key

- Issue templates
  - Added templates for bug report and documentation changes 

- Actions
  - Added release action
  - Added multi-framework distributable build tests

### Updated
- Updated endpoints for Sub-Account
New parameter clientTranId added in POST /sapi/v1/sub-account/universalTransfer and GET /sapi/v1/sub-account/universalTransfer to support custom transfer id

- Updated endpoint for Wallet and Futures
GET /sapi/v1/asset/transfer
GET /sapi/v1/futures/transfer
GET /sapi/v1/accountSnapshot
The query time range of both endpoints are shortened to support data query within the last 6 months only, where startTime does not support selecting a timestamp beyond 6 months.
If you do not specify startTime and endTime, the data of the last 7 days will be returned by default.

- Updated endpoints for Wallet
New parameter walletType added in POST /sapi/v1/capital/withdraw/apply

- Updated endpoints for Margin
Removed out limit from GET /sapi/v1/margin/interestRateHistory
As the Mining account is merged into Funding account, transfer types MAIN_MINING, MINING_MAIN, MINING_UMFUTURE, MARGIN_MINING, and MINING_MARGIN will be discontinued in Universal Transfer endpoint POST /sapi/v1/asset/transfer on January 05, 2022 08:00 AM UTC

- Resolved lint warnings

- Improved Http Exceptions