### PR TITLE
rc-1.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -64,7 +64,7 @@ body:
     attributes:
       label: "Environment"
       description: "Any additional differences in your environment which may relate to the issue"
-      placeholder: ""
+      placeholder: "Differences..."
   - type: textarea
     id: dotnet-info
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.0 - 2022-02-16
+### Added
+- New endpoints for Binance Code, named as Gift Card to avoid technical confusion.
+  - `POST /sapi/v1/giftcard/createCode` to create a Binance Code.
+  - `POST /sapi/v1/giftcard/redeemCode` to redeem a Binance Code.
+  - `GET /sapi/v1/giftcard/verify` to verify a Binance Code.
+
 ## 1.1.0 - 2022-01-19
 ### Added
 - New endpoints for BSwap

--- a/Examples/CSharp/GiftCard/CreateBinanceCode_Example.cs
+++ b/Examples/CSharp/GiftCard/CreateBinanceCode_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.GiftCardExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class CreateBinanceCode_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<CreateBinanceCode_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var giftCard = new GiftCard(httpClient);
+
+            var result = await giftCard.CreateBinanceCode("BUSD", 20.01);
+        }
+    }
+}

--- a/Examples/CSharp/GiftCard/RedeemBinanceCode_Example.cs
+++ b/Examples/CSharp/GiftCard/RedeemBinanceCode_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.GiftCardExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class RedeemBinanceCode_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<RedeemBinanceCode_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var giftCard = new GiftCard(httpClient);
+
+            var result = await giftCard.RedeemBinanceCode("X1X1X1X1X1X11XX1X11X1");
+        }
+    }
+}

--- a/Examples/CSharp/GiftCard/VerifyBinanceCode_Example.cs
+++ b/Examples/CSharp/GiftCard/VerifyBinanceCode_Example.cs
@@ -1,0 +1,30 @@
+namespace Binance.Spot.GiftCardExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class VerifyBinanceCode_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<VerifyBinanceCode_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            var giftCard = new GiftCard(httpClient);
+
+            var result = await giftCard.VerifyBinanceCode("00000000000000000");
+        }
+    }
+}

--- a/Examples/FSharp/GiftCard/CreateBinanceCode_Example.fs
+++ b/Examples/FSharp/GiftCard/CreateBinanceCode_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let giftCard = new GiftCard(httpClient)
+    
+    let result = giftCard.CreateBinanceCode("BUSD", 20.01) |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/GiftCard/RedeemBinanceCode_Example.fs
+++ b/Examples/FSharp/GiftCard/RedeemBinanceCode_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let giftCard = new GiftCard(httpClient)
+    
+    let result = giftCard.RedeemBinanceCode("X1X1X1X1X1X11XX1X11X1") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/GiftCard/VerifyBinanceCode_Example.fs
+++ b/Examples/FSharp/GiftCard/VerifyBinanceCode_Example.fs
@@ -1,0 +1,24 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+    
+    let giftCard = new GiftCard(httpClient)
+    
+    let result = giftCard.VerifyBinanceCode("00000000000000000") |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Binance Public API Connector DotNET
 
+[![[Nuget]](https://img.shields.io/nuget/v/Binance.Spot)](https://www.nuget.org/packages/Binance.Spot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 This is a lightweight library that works as a connector to [Binance public API](https://github.com/binance/binance-spot-api-docs)

--- a/Src/Spot/.nuspec
+++ b/Src/Spot/.nuspec
@@ -6,12 +6,12 @@
         <title>Binance Connector</title>
         <description>This is a lightweight library that works as a connector to Binance public API.</description>
         <icon>icon.png</icon>
-        <tags></tags>
+        <tags>binance api binance-api spot exchange wrapper connector standard dotnet csharp fsharp</tags>
         <license type="file">LICENSE.md</license>
-        <releaseNotes>CHANGELOG.md</releaseNotes>
+        <releaseNotes>https://github.com/binance/binance-connector-dotnet/blob/master/CHANGELOG.md</releaseNotes>
         <readme>README.md</readme>
         <repository type="git" url="https://github.com/binance/binance-connector-dotnet" branch="master"></repository>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <authors>binance</authors>
 
         <dependencies>

--- a/Src/Spot/GiftCard.cs
+++ b/Src/Spot/GiftCard.cs
@@ -1,0 +1,102 @@
+namespace Binance.Spot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Spot.Models;
+
+    public class GiftCard : SpotService
+    {
+        public GiftCard(string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : this(new HttpClient(), baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        public GiftCard(HttpClient httpClient, string baseUrl = DEFAULT_SPOT_BASE_URL, string apiKey = null, string apiSecret = null)
+        : base(httpClient, baseUrl: baseUrl, apiKey: apiKey, apiSecret: apiSecret)
+        {
+        }
+
+        private const string CREATE_BINANCE_CODE = "/sapi/v1/giftcard/createCode";
+
+        /// <summary>
+        /// This API is for creating a Binance Code. To get started with, please make sure:.<para />
+        /// You have a Binance account.<para />
+        /// You have passed kyc.<para />
+        /// You have a sufﬁcient balance in your Binance funding wallet.<para />
+        /// You need Enable Withdrawals for the API Key which requests this endpoint.<para />
+        /// Weight(IP): 1.<para />
+        /// Daily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H.
+        /// </summary>
+        /// <param name="token">The coin type contained in the Binance Code.</param>
+        /// <param name="amount">The amount of the coin.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Binance Gift Card Code.</returns>
+        public async Task<string> CreateBinanceCode(string token, double amount, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                CREATE_BINANCE_CODE,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "token", token },
+                    { "amount", amount },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string REDEEM_BINANCE_CODE = "/sapi/v1/giftcard/redeemCode";
+
+        /// <summary>
+        /// This API is for redeeming the Binance Code. Once redeemed, the coins will be deposited in your funding wallet.<para />
+        /// Please note that if you enter the wrong code 5 times within 24 hours, you will no longer be able to redeem any Binance Code that day.<para />
+        /// Weight(IP): 1.
+        /// </summary>
+        /// <param name="code">Binance code.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Binance Gift Card details.</returns>
+        public async Task<string> RedeemBinanceCode(string code, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                REDEEM_BINANCE_CODE,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "code", code },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
+        private const string VERIFY_BINANCE_CODE = "/sapi/v1/giftcard/verify";
+
+        /// <summary>
+        /// This API is for verifying whether the Binance Code is valid or not by entering Binance Code or reference number.<para />
+        /// Please note that if you enter the wrong binance code 5 times within an hour, you will no longer be able to verify any binance code for that hour.<para />
+        /// Weight(IP): 1.
+        /// </summary>
+        /// <param name="referenceNo">reference number.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Binance Gift Card details.</returns>
+        public async Task<string> VerifyBinanceCode(string referenceNo, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                VERIFY_BINANCE_CODE,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "referenceNo", referenceNo },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+    }
+}

--- a/Tests/Spot.Tests/GiftCard_Tests.cs
+++ b/Tests/Spot.Tests/GiftCard_Tests.cs
@@ -1,0 +1,88 @@
+namespace Binance.Spot.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using Binance.Spot.Models;
+    using Moq;
+    using Moq.Protected;
+    using Xunit;
+
+    public class GiftCard_Tests
+    {
+        private string apiKey = "api-key";
+        private string apiSecret = "api-secret";
+
+        #region CreateBinanceCode
+        [Fact]
+        public async void CreateBinanceCode_Response()
+        {
+            var responseContent = "{\"code\":\"000000\",\"message\":\"success\",\"data\":{\"referenceNo\":\"0033002327977405\",\"code\":\"AOGANK3NB4GIT3C6\"},\"success\":true}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/giftcard/createCode", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            GiftCard giftCard = new GiftCard(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await giftCard.CreateBinanceCode("BUSD", 20.01);
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region RedeemBinanceCode
+        [Fact]
+        public async void RedeemBinanceCode_Response()
+        {
+            var responseContent = "{\"code\":\"000000\",\"message\":\"success\",\"data\":{\"token\":\"BNB\",\"amount\":\"10\",\"referenceNo\":\"0033002327977405\",\"identityNo\":\"10316281761814589440\"},\"success\":true}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/giftcard/redeemCode", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            GiftCard giftCard = new GiftCard(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await giftCard.RedeemBinanceCode("X1X1X1X1X1X11XX1X11X1");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
+        #region VerifyBinanceCode
+        [Fact]
+        public async void VerifyBinanceCode_Response()
+        {
+            var responseContent = "{\"code\":\"000000\",\"message\":\"success\",\"data\":{\"valid\":true,\"token\":\"BNB\",\"amount\":\"0.00000001\"},\"success\":true}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/giftcard/verify", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            GiftCard giftCard = new GiftCard(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await giftCard.VerifyBinanceCode("00000000000000000");
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
### Added
- New endpoints for Binance Code, named as Gift Card to avoid technical confusion.
`POST /sapi/v1/giftcard/createCode` to create a Binance Code.
`POST /sapi/v1/giftcard/redeemCode` to redeem a Binance Code.
`GET /sapi/v1/giftcard/verify` to verify a Binance Code.

- Nuget Badge to README.md

### Updated
- Issue templates
  - Bug report - Environment field placeholder 