### PR TITLE
Rc-1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.7.0 - 2022-07-19
+
+### Added
+- New endpoint for Margin:
+  - `POST /sapi/v3/asset/getUserAsset` to get user assets.
+
+- New endpoint for Wallet:
+  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.
+
+### Changed
+- Update endpoint for Convert:
+  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)
+
 ## 1.6.0 - 2022-07-04
 
 ### Added

--- a/Examples/CSharp/MarginAccountTrade/MarginDustlog_Example.cs
+++ b/Examples/CSharp/MarginAccountTrade/MarginDustlog_Example.cs
@@ -1,0 +1,33 @@
+namespace Binance.Spot.MarginAccountTradeExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class MarginDustlog_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<MarginDustlog_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            string apiKey = "api-key";
+            string apiSecret = "api-secret";
+
+            var marginAccountTrade = new MarginAccountTrade(httpClient, apiKey: apiKey, apiSecret: apiSecret);
+
+            var result = await marginAccountTrade.MarginDustlog();
+        }
+    }
+}

--- a/Examples/CSharp/Wallet/UserAsset_Example.cs
+++ b/Examples/CSharp/Wallet/UserAsset_Example.cs
@@ -1,0 +1,33 @@
+namespace Binance.Spot.WalletExamples
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Binance.Common;
+    using Binance.Spot;
+    using Binance.Spot.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class UserAsset_Example
+    {
+        public static async Task Main(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+            ILogger logger = loggerFactory.CreateLogger<UserAsset_Example>();
+
+            HttpMessageHandler loggingHandler = new BinanceLoggingHandler(logger: logger);
+            HttpClient httpClient = new HttpClient(handler: loggingHandler);
+
+            string apiKey = "api-key";
+            string apiSecret = "api-secret";
+
+            var wallet = new Wallet(httpClient, apiKey: apiKey, apiSecret: apiSecret);
+
+            var result = await wallet.UserAsset();
+        }
+    }
+}

--- a/Examples/FSharp/MarginAccountTrade/MarginDustlog_Example.fs
+++ b/Examples/FSharp/MarginAccountTrade/MarginDustlog_Example.fs
@@ -1,0 +1,27 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+
+    let apiKey = "api-key";
+    let apiSecret = "api-secret";
+    
+    let marginAccountTrade = new MarginAccountTrade(httpClient, apiKey = apiKey, apiSecret = apiSecret)
+    
+    let result = marginAccountTrade.MarginDustlog() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Examples/FSharp/Wallet/UserAsset_Example.fs
+++ b/Examples/FSharp/Wallet/UserAsset_Example.fs
@@ -1,0 +1,27 @@
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open Binance.Common
+open Binance.Spot
+open Binance.Spot.Models
+
+[<EntryPoint>]
+let main argv =
+    let loggerFactory = LoggerFactory.Create(fun (builder:ILoggingBuilder) -> 
+        builder.AddConsole() |> ignore
+    )
+    let logger = loggerFactory.CreateLogger()
+
+    let loggingHandler = new BinanceLoggingHandler(logger)
+    let httpClient = new HttpClient(loggingHandler)
+
+    let apiKey = "api-key";
+    let apiSecret = "api-secret";
+    
+    let wallet = new Wallet(httpClient, apiKey = apiKey, apiSecret = apiSecret)
+    
+    let result = wallet.UserAsset() |> Async.AwaitTask |> Async.RunSynchronously
+    
+    0

--- a/Src/Spot/.nuspec
+++ b/Src/Spot/.nuspec
@@ -11,7 +11,7 @@
         <releaseNotes>https://github.com/binance/binance-connector-dotnet/blob/master/CHANGELOG.md</releaseNotes>
         <readme>README.md</readme>
         <repository type="git" url="https://github.com/binance/binance-connector-dotnet" branch="master"></repository>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <authors>binance</authors>
 
         <dependencies>

--- a/Src/Spot/Convert.cs
+++ b/Src/Spot/Convert.cs
@@ -22,7 +22,7 @@ namespace Binance.Spot
 
         /// <summary>
         /// - The max interval between startTime and endTime is 30 days.<para />
-        /// Weight(UID): 3000.
+        /// Weight(UID): 100.
         /// </summary>
         /// <param name="startTime">UTC timestamp in ms.</param>
         /// <param name="endTime">UTC timestamp in ms.</param>

--- a/Src/Spot/MarginAccountTrade.cs
+++ b/Src/Spot/MarginAccountTrade.cs
@@ -1297,5 +1297,31 @@ namespace Binance.Spot
 
             return result;
         }
+
+        private const string MARGIN_DUSTLOG = "/sapi/v1/margin/dribblet";
+
+        /// <summary>
+        /// Query the historical information of user's margin account small-value asset conversion BNB.<para />
+        /// Weight(IP): 1.
+        /// </summary>
+        /// <param name="startTime">UTC timestamp in ms.</param>
+        /// <param name="endTime">UTC timestamp in ms.</param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>Usage..</returns>
+        public async Task<string> MarginDustlog(long? startTime = null, long? endTime = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                MARGIN_DUSTLOG,
+                HttpMethod.Get,
+                query: new Dictionary<string, object>
+                {
+                    { "startTime", startTime },
+                    { "endTime", endTime },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
     }
 }

--- a/Src/Spot/Wallet.cs
+++ b/Src/Spot/Wallet.cs
@@ -603,6 +603,32 @@ namespace Binance.Spot
             return result;
         }
 
+        private const string USER_ASSET = "/sapi/v3/asset/getUserAsset";
+
+        /// <summary>
+        /// Get user assets, just for positive data.<para />
+        /// Weight(IP): 5.
+        /// </summary>
+        /// <param name="asset">If asset is blank, then query all positive assets user have.</param>
+        /// <param name="needBtcValuation"></param>
+        /// <param name="recvWindow">The value cannot be greater than 60000.</param>
+        /// <returns>User assets.</returns>
+        public async Task<string> UserAsset(string asset = null, string needBtcValuation = null, long? recvWindow = null)
+        {
+            var result = await this.SendSignedAsync<string>(
+                USER_ASSET,
+                HttpMethod.Post,
+                query: new Dictionary<string, object>
+                {
+                    { "asset", asset },
+                    { "needBtcValuation", needBtcValuation },
+                    { "recvWindow", recvWindow },
+                    { "timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() },
+                });
+
+            return result;
+        }
+
         private const string GET_API_KEY_PERMISSION = "/sapi/v1/account/apiRestrictions";
 
         /// <summary>

--- a/Tests/Spot.Tests/MarginAccountTrade_Tests.cs
+++ b/Tests/Spot.Tests/MarginAccountTrade_Tests.cs
@@ -1043,5 +1043,29 @@ namespace Binance.Spot.Tests
             Assert.Equal(responseContent, result);
         }
         #endregion
+
+        #region MarginDustlog
+        [Fact]
+        public async void MarginDustlog_Response()
+        {
+            var responseContent = "{\"total\":8,\"userAssetDribblets\":[{\"operateTime\":1615985535000,\"totalTransferedAmount\":\"0.00132256\",\"totalServiceChargeAmount\":\"0.00002699\",\"transId\":45178372831,\"userAssetDribbletDetails\":[{\"transId\":4359321,\"serviceChargeAmount\":\"0.000009\",\"amount\":\"0.0009\",\"operateTime\":1615985535000,\"transferedAmount\":\"0.000441\",\"fromAsset\":\"USDT\"},{\"transId\":4359321,\"serviceChargeAmount\":\"0.00001799\",\"amount\":\"0.0009\",\"operateTime\":1615985535000,\"transferedAmount\":\"0.00088156\",\"fromAsset\":\"ETH\"}]}]}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v1/margin/dribblet", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            MarginAccountTrade marginAccountTrade = new MarginAccountTrade(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await marginAccountTrade.MarginDustlog();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
     }
 }

--- a/Tests/Spot.Tests/Wallet_Tests.cs
+++ b/Tests/Spot.Tests/Wallet_Tests.cs
@@ -492,6 +492,30 @@ namespace Binance.Spot.Tests
         }
         #endregion
 
+        #region UserAsset
+        [Fact]
+        public async void UserAsset_Response()
+        {
+            var responseContent = "[{\"asset\":\"AVAX\",\"free\":\"1\",\"locked\":\"0\",\"freeze\":\"0\",\"withdrawing\":\"0\",\"ipoable\":\"0\",\"btcValuation\":\"0\"},{\"asset\":\"BCH\",\"free\":\"0.9\",\"locked\":\"0\",\"freeze\":\"0\",\"withdrawing\":\"0\",\"ipoable\":\"0\",\"btcValuation\":\"0\"}]";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/sapi/v3/asset/getUserAsset", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+            Wallet wallet = new Wallet(
+                new HttpClient(mockMessageHandler.Object),
+                apiKey: this.apiKey,
+                apiSecret: this.apiSecret);
+
+            var result = await wallet.UserAsset();
+
+            Assert.Equal(responseContent, result);
+        }
+        #endregion
+
         #region GetApiKeyPermission
         [Fact]
         public async void GetApiKeyPermission_Response()


### PR DESCRIPTION
New endpoint for Margin:
- `POST /sapi/v3/asset/getUserAsset` to get user assets.

New endpoint for Wallet:
- `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.

Update endpoint for Convert:
  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)